### PR TITLE
fix: Less fancy is prod check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
+import type {OptionalLogger} from '@rocicorp/logger';
 import type {
   ReadonlyJSONValue,
   ReadTransaction,
   WriteTransaction,
 } from 'replicache';
 import {z, ZodType} from 'zod';
-import type {OptionalLogger} from '@rocicorp/logger';
 
 export type Update<T> = Entity & Partial<T>;
 
 export function parseIfDebug<T>(schema: ZodType<T>, val: ReadonlyJSONValue): T {
-  if (globalThis.process?.env?.NODE_ENV !== 'production') {
-    return schema.parse(val);
+  if (process.env.NODE_ENV === 'production') {
+    return val as T;
   }
-  return val as T;
+  return schema.parse(val);
 }
 
 export type GenerateResult<T extends Entity> = {

--- a/web-test-runner.config.cjs
+++ b/web-test-runner.config.cjs
@@ -8,6 +8,14 @@ const config = {
       ui: 'tdd',
     },
   },
+  testRunnerHtml: testFramework =>
+    `<!doctype html>
+    <html>
+    <body>
+      <script>window.process = { env: { NODE_ENV: "development" } }</script>
+      <script type="module" src="${testFramework}"></script>
+    </body>
+  </html>`,
 };
 
 module.exports = config;


### PR DESCRIPTION
Use `process.env.NODE_ENV` instead of
`globalThis?.process?.env?.NODE_ENV`. With the latter we do not get dead code elimination.