### PR TITLE
Rename `entries` -> `listEntries`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ List values matching criteria.
 
 List ids matching criteria.
 
-### `entries(tx: ReadTransaction, options?: {startAtID?: string, limit:? number}) => Promise<[string, T][]>`
+### `listEntries(tx: ReadTransaction, options?: {startAtID?: string, limit:? number}) => Promise<[string, T][]>`
 
-List [id, value] entries matching criteria.
+List `[id, value]` entries matching criteria.
 
 ## Upgrade from 0.6
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -30,7 +30,7 @@ const {
   has: hasE1,
   list: listE1,
   listIDs: listIDsE1,
-  entries: entriesE1,
+  listEntries: listEntriesE1,
 } = generate<E1>('e1', e1.parse);
 
 async function directWrite(
@@ -681,7 +681,7 @@ suite('listIDs', () => {
   }
 });
 
-suite('entries', () => {
+suite('listEntries', () => {
   type Case = {
     name: string;
     prefix: string;
@@ -750,7 +750,7 @@ suite('entries', () => {
       let error = undefined;
       let actual = undefined;
       try {
-        actual = await rep.query(tx => entriesE1(tx, c.options));
+        actual = await rep.query(tx => listEntriesE1(tx, c.options));
       } catch (e) {
         if (e instanceof ZodError) {
           error = e.format();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export type GenerateResult<T extends Entity> = {
   /** List ids matching criteria. */
   listIDs: (tx: ReadTransaction, options?: ListOptions) => Promise<string[]>;
   /** List [id, value] entries matching criteria. */
-  entries: (
+  listEntries: (
     tx: ReadTransaction,
     options?: ListOptions,
   ) => Promise<[string, T][]>;
@@ -65,8 +65,8 @@ export function generate<T extends Entity>(
       listImpl(prefix, parse, tx, options),
     listIDs: (tx: ReadTransaction, options?: ListOptions) =>
       listIDsImpl(prefix, tx, options),
-    entries: (tx: ReadTransaction, options?: ListOptions) =>
-      entriesImpl(prefix, parse, tx, options),
+    listEntries: (tx: ReadTransaction, options?: ListOptions) =>
+      listEntriesImpl(prefix, parse, tx, options),
   };
 }
 
@@ -155,7 +155,6 @@ async function updateImpl<T extends Entity>(
 async function deleteImpl(prefix: string, tx: WriteTransaction, id: string) {
   await tx.del(key(prefix, id));
 }
-
 export type ListOptions = {
   startAtID?: string;
   limit?: number;
@@ -204,7 +203,7 @@ async function listIDsImpl(
   return result;
 }
 
-async function entriesImpl<T extends Entity>(
+async function listEntriesImpl<T extends Entity>(
   prefix: string,
   parse: Parse<T> | undefined,
   tx: ReadTransaction,


### PR DESCRIPTION
Looking at it closer in context, I prefer the consistency with existing names.