### PR TITLE
fix: npm package had wrong files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,8 @@
     "zod": "^3.22.4"
   },
   "files": [
-    "out/index.d.ts",
-    "out/index.js",
-    "out/index.d.ts.map",
-    "out/index.js.map"
+    "out/",
+    "!out/*.test.*"
   ],
   "eslintConfig": {
     "extends": "@rocicorp/eslint-config"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "allowJs": true,
     "skipLibCheck": true
   },
-  "include": ["**/*.ts", "**/*.js"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
By only treating src/ as input we ensure that generated files are put in `out`.

Make sure to include all non test files from out/ in the npm package.