### PR TITLE
feat: generatePresence take 2

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -61,3 +61,4 @@ jobs:
       - name: Install Playwright Deps
         run: npx playwright install --with-deps
       - run: npm run test
+      - run: npm run test-types

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 tsconfig.tsbuildinfo
+tsconfig.vitest-temp.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rocicorp/logger": "^5.2.1",
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/reflect": "^0.39.202401100534",
-        "@vitest/browser": "^1.2.1",
+        "@vitest/browser": "1.2.2",
         "@web/dev-server": "^0.4.1",
         "@web/dev-server-esbuild": "^1.0.1",
         "@web/dev-server-import-maps": "^0.2.0",
@@ -21,9 +21,9 @@
         "@web/test-runner-playwright": "^0.11.0",
         "nanoid": "^5.0.4",
         "playwright": "^1.41.1",
-        "replicache": "14.0.3",
+        "replicache": "14.1.0",
         "typescript": "^5.3.3",
-        "vitest": "^1.2.1",
+        "vitest": "1.2.2",
         "zod": "^3.22.4"
       }
     },
@@ -1603,12 +1603,12 @@
       "dev": true
     },
     "node_modules/@vitest/browser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-1.2.1.tgz",
-      "integrity": "sha512-jhaQ15zWYAwz8anXgmLW0yAVLCXdT8RFv7LeW9bg7sMlvGJaTCTIHaHWFvCdADF/i62+22tnrzgiiqSnApjXtA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-1.2.2.tgz",
+      "integrity": "sha512-N8myxNVLbS9AbZ7B2cK33HTGYVzUTDArbMh3hLojOxaj7s7ZrBYYmzs0Q5J2wyDrOgs51p6OUrrzAIb1Z+Ck3A==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.2.1",
+        "@vitest/utils": "1.2.2",
         "magic-string": "^0.30.5",
         "sirv": "^2.0.4"
       },
@@ -1633,13 +1633,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.1.tgz",
-      "integrity": "sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.2.tgz",
+      "integrity": "sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.2.1",
-        "@vitest/utils": "1.2.1",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -1647,12 +1647,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.1.tgz",
-      "integrity": "sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.2.tgz",
+      "integrity": "sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.2.1",
+        "@vitest/utils": "1.2.2",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.1.tgz",
-      "integrity": "sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.2.tgz",
+      "integrity": "sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -1702,9 +1702,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.1.tgz",
-      "integrity": "sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.2.tgz",
+      "integrity": "sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -1714,9 +1714,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.2.tgz",
+      "integrity": "sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -5796,9 +5796,9 @@
       }
     },
     "node_modules/replicache": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/replicache/-/replicache-14.0.3.tgz",
-      "integrity": "sha512-BXj8Wg2LS15h+3H66ws5XDHlNT88mLjqEkvxhecg4OaqnfNMBJRr5/gM9Chu4gVciH5w90G1X6JTsshgvW2FBg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/replicache/-/replicache-14.1.0.tgz",
+      "integrity": "sha512-hFCnTBvFTw4j/cggSlzPkDpFkXnYGgSI18qYBTRtPR24m+J92dGvorGqh9+CFvzeSxF+VTf7zeAvF/MKqb3y+w==",
       "dev": true,
       "dependencies": {
         "@badrap/valita": "^0.3.0",
@@ -6800,9 +6800,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.1.tgz",
-      "integrity": "sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.2.tgz",
+      "integrity": "sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -6822,16 +6822,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.1.tgz",
-      "integrity": "sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.2.tgz",
+      "integrity": "sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.2.1",
-        "@vitest/runner": "1.2.1",
-        "@vitest/snapshot": "1.2.1",
-        "@vitest/spy": "1.2.1",
-        "@vitest/utils": "1.2.1",
+        "@vitest/expect": "1.2.2",
+        "@vitest/runner": "1.2.2",
+        "@vitest/snapshot": "1.2.2",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "acorn-walk": "^8.3.2",
         "cac": "^6.7.14",
         "chai": "^4.3.10",
@@ -6844,9 +6844,9 @@
         "std-env": "^3.5.0",
         "strip-literal": "^1.3.0",
         "tinybench": "^2.5.1",
-        "tinypool": "^0.8.1",
+        "tinypool": "^0.8.2",
         "vite": "^5.0.0",
-        "vite-node": "1.2.1",
+        "vite-node": "1.2.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "@web/test-runner": "^0.18.0",
     "@web/test-runner-playwright": "^0.11.0",
     "nanoid": "^5.0.4",
-    "replicache": "14.0.3",
+    "replicache": "14.1.0",
     "typescript": "^5.3.3",
     "zod": "^3.22.4",
-    "@vitest/browser": "^1.2.1",
+    "@vitest/browser": "1.2.2",
     "playwright": "^1.41.1",
-    "vitest": "^1.2.1"
+    "vitest": "1.2.2"
   },
   "files": [
     "out/",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "build": "tsc",
     "prepack": "npm run check-format && npm run lint && npm run test && npm run build",
-    "test": "vitest run --browser.provider=playwright --browser.name=chromium --browser.headless",
-    "test:watch": "vitest watch --browser.provider=playwright --browser.name=chromium --browser.headless"
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test-types": "vitest run --typecheck.only --no-browser.enabled",
+    "test-types:watch": "vitest watch --typecheck.only --no-browser.enabled"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/generate-presence.test-d.ts
+++ b/src/generate-presence.test-d.ts
@@ -1,0 +1,339 @@
+import {assertType, expectTypeOf, test} from 'vitest';
+import {z} from 'zod';
+import {generatePresence} from './generate-presence.js';
+import {ReadTransaction, WriteTransaction} from './generate.js';
+
+const entryNoID = z
+  .object({
+    clientID: z.string(),
+    str: z.string(),
+    optStr: z.string().optional(),
+  })
+  .strict();
+
+type EntryNoID = z.infer<typeof entryNoID>;
+
+const {
+  init: initEntryNoID,
+  set: setEntryNoID,
+  update: updateEntryNoID,
+  delete: deleteEntryNoID,
+  get: getEntryNoID,
+  mustGet: mustGetEntryNoID,
+  has: hasEntryNoID,
+  list: listEntryNoID,
+  listIDs: listIDsEntryNoID,
+  listClientIDs: listClientIDsEntryNoID,
+  listEntries: listEntriesEntryNoID,
+} = generatePresence<EntryNoID>('entryNoID', entryNoID.parse);
+
+const entryID = z
+  .object({
+    clientID: z.string(),
+    id: z.string(),
+    str: z.string(),
+    optStr: z.string().optional(),
+  })
+  .strict();
+
+type EntryID = z.infer<typeof entryID>;
+
+const {
+  init: initEntryID,
+  set: setEntryID,
+  update: updateEntryID,
+  delete: deleteEntryID,
+  get: getEntryID,
+  mustGet: mustGetEntryID,
+  has: hasEntryID,
+  list: listEntryID,
+  listIDs: listIDsEntryID,
+  listClientIDs: listClientIDsEntryID,
+  listEntries: listEntriesEntryID,
+} = generatePresence<EntryID>('entryID', entryID.parse);
+
+declare const rtx: ReadTransaction;
+declare const wtx: WriteTransaction;
+
+test('init', async () => {
+  await initEntryID(wtx, {clientID: 'foo', id: 'bar', str: 'baz'});
+  await initEntryID(wtx, {id: 'bar', str: 'baz'});
+  // @ts-expect-error missing str
+  await initEntryID(wtx, {id: 'bar'});
+  // @ts-expect-error missing id
+  await initEntryID(wtx, {clientID: 'foo', str: 'baz'});
+  expectTypeOf(initEntryID).returns.resolves.toBeBoolean();
+
+  await initEntryNoID(wtx, {clientID: 'foo', str: 'baz'});
+  await initEntryNoID(wtx, {str: 'baz'});
+  // @ts-expect-error Type 'number' is not assignable to type 'string'.
+  await initEntryNoID(wtx, {clientID: 'foo', str: 42});
+  // @ts-expect-error missing str
+  await initEntryNoID(wtx, {});
+  expectTypeOf(initEntryNoID).returns.resolves.toBeBoolean();
+});
+
+test('update', async () => {
+  await updateEntryID(wtx, {clientID: 'foo', id: 'bar', str: 'baz'});
+  await updateEntryID(wtx, {id: 'bar', str: 'baz'});
+  await updateEntryID(wtx, {id: 'bar'});
+  // @ts-expect-error missing id
+  await updateEntryID(wtx, {clientID: 'foo', str: 'baz'});
+  expectTypeOf(updateEntryID).returns.resolves.toBeVoid();
+
+  await updateEntryNoID(wtx, {clientID: 'foo', str: 'baz'});
+  await updateEntryNoID(wtx, {str: 'baz'});
+  // @ts-expect-error Type 'number' is not assignable to type 'string'.
+  await updateEntryNoID(wtx, {clientID: 'foo', str: 42});
+
+  expectTypeOf(updateEntryNoID).returns.resolves.toBeVoid();
+});
+
+test('delete', async () => {
+  await deleteEntryID(wtx, {clientID: 'cid', id: 'bar'});
+  await deleteEntryID(wtx, {id: 'bar'});
+  expectTypeOf(deleteEntryID)
+    .parameter(1)
+    .toEqualTypeOf<{clientID?: string | undefined; id: string} | undefined>();
+  expectTypeOf(deleteEntryID).returns.resolves.toBeVoid();
+
+  // @ts-expect-error extra str
+  await deleteEntryID(wtx, {clientID: 'foo', id: 'bar', str: 'baz'});
+  // @ts-expect-error extra str
+  await deleteEntryID(wtx, {id: 'bar', str: 'baz'});
+  // @ts-expect-error missing id
+  await deleteEntryID(wtx, {clientID: 'foo'});
+  // @ts-expect-error missing id
+  await deleteEntryID(wtx, {});
+  expectTypeOf(deleteEntryID)
+    .parameter(1)
+    .not.toEqualTypeOf<{clientID?: string | undefined} | undefined>();
+
+  await deleteEntryNoID(wtx, {clientID: 'foo'});
+  await deleteEntryNoID(wtx, {});
+  await deleteEntryNoID(wtx, undefined);
+  await deleteEntryNoID(wtx);
+  expectTypeOf(deleteEntryNoID)
+    .parameter(1)
+    .toMatchTypeOf<{clientID?: string | undefined} | undefined>();
+  expectTypeOf(deleteEntryNoID).returns.resolves.toBeVoid();
+
+  // @ts-expect-error extra str
+  await deleteEntryNoID(wtx, {clientID: 'foo', str: 'baz'});
+  // @ts-expect-error extra str
+  await deleteEntryNoID(wtx, {str: 'baz'});
+  // @ts-expect-error Type 'number' is not assignable to type 'string'.
+  await deleteEntryNoID(wtx, {clientID: 'foo', str: 42});
+  expectTypeOf(deleteEntryNoID)
+    .parameter(1)
+    .not.toEqualTypeOf<
+      {clientID?: string | undefined; id: string} | undefined
+    >();
+});
+
+test('set', () => {
+  assertType<
+    (
+      tx: WriteTransaction,
+      id: {clientID?: string; id: string; str: string; optStr?: string},
+    ) => Promise<void>
+  >(setEntryID);
+
+  assertType<
+    (
+      tx: WriteTransaction,
+      id: {clientID?: string; str: string; optStr?: string},
+    ) => Promise<void>
+  >(setEntryNoID);
+});
+
+test('get', () => {
+  assertType<
+    (
+      tx: ReadTransaction,
+      id: {clientID?: string} | undefined,
+    ) => Promise<EntryNoID | undefined>
+  >(getEntryNoID);
+
+  assertType<
+    (
+      tx: ReadTransaction,
+      id: {clientID?: string; id: string},
+    ) => Promise<EntryID | undefined>
+  >(getEntryID);
+  expectTypeOf(getEntryID).not.toMatchTypeOf<
+    (
+      tx: ReadTransaction,
+      id: {clientID?: string},
+    ) => Promise<EntryID | undefined>
+  >();
+
+  assertType<
+    (
+      tx: ReadTransaction,
+      id: {clientID?: string},
+    ) => Promise<EntryID | undefined>
+    // @ts-expect-error missing id
+  >(getEntryID);
+
+  expectTypeOf(getEntryNoID)
+    .parameter(1)
+    .toEqualTypeOf<{clientID?: string} | undefined>();
+  expectTypeOf(getEntryNoID).returns.resolves.toEqualTypeOf<
+    EntryNoID | undefined
+  >();
+
+  expectTypeOf(getEntryID)
+    .parameter(1)
+    .toEqualTypeOf<{clientID?: string; id: string} | undefined>();
+  expectTypeOf(getEntryID).returns.resolves.toEqualTypeOf<
+    EntryID | undefined
+  >();
+});
+
+test('mustGet', () => {
+  expectTypeOf(mustGetEntryNoID)
+    .parameter(1)
+    .toEqualTypeOf<{clientID?: string} | undefined>();
+  expectTypeOf(mustGetEntryNoID).returns.resolves.not.toBeUndefined();
+  expectTypeOf(mustGetEntryNoID).returns.resolves.toEqualTypeOf<EntryNoID>();
+
+  expectTypeOf(mustGetEntryID)
+    .parameter(1)
+    .toEqualTypeOf<{clientID?: string; id: string} | undefined>();
+  expectTypeOf(mustGetEntryID).returns.resolves.not.toBeUndefined();
+  expectTypeOf(mustGetEntryID).returns.resolves.toEqualTypeOf<EntryID>();
+});
+
+test('has', async () => {
+  await hasEntryNoID(rtx, {clientID: 'foo'});
+  await hasEntryNoID(rtx, {});
+  await hasEntryNoID(rtx, undefined);
+  await hasEntryNoID(rtx);
+  assertType<
+    (
+      tx: ReadTransaction,
+      id?: {clientID?: string} | undefined,
+    ) => Promise<boolean>
+  >(hasEntryNoID);
+
+  // @ts-expect-error extra id
+  await hasEntryNoID(rtx, {id: 'bar'});
+  // @ts-expect-error extra str
+  await hasEntryNoID(rtx, {str: 'bar'});
+
+  await hasEntryID(rtx, {clientID: 'foo', id: 'b'});
+  await hasEntryID(rtx, {id: 'b'});
+
+  assertType<
+    (
+      tx: ReadTransaction,
+      id: {clientID?: string; id: string},
+    ) => Promise<boolean>
+  >(hasEntryID);
+
+  // @ts-expect-error missing id
+  await hasEntryID(rtx, {});
+  // @ts-expect-error missing id
+  await hasEntryID(rtx, {clientID: 'foo'});
+  // @ts-expect-error extra str
+  await hasEntryID(rtx, {str: 'bar'});
+
+  // TODO(arv): Fix these
+  // await hasEntryID(rtx, undefined);
+  // await hasEntryID(rtx);
+});
+
+test('list', async () => {
+  assertType<EntryNoID[]>(await listEntryNoID(rtx));
+  await listEntryNoID(rtx, {});
+  await listEntryNoID(rtx, {limit: 1});
+  await listEntryNoID(rtx, {startAtID: {clientID: 'cid'}});
+  await listEntryNoID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  // @ts-expect-error unknown property foo
+  await listEntryNoID(rtx, {startAtID: {clientID: 'cid', foo: 'bar'}});
+  // @ts-expect-error unknown property id
+  await listEntryNoID(rtx, {startAtID: {clientID: 'cid', id: 'bar'}});
+
+  assertType<EntryID[]>(await listEntryID(rtx));
+  await listEntryID(rtx, {});
+  await listEntryID(rtx, {limit: 1});
+  await listEntryID(rtx, {startAtID: {clientID: 'cid'}});
+  await listEntryID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  await listEntryID(rtx, {startAtID: {clientID: 'cid', id: 'b'}});
+  // @ts-expect-error unknown property foo
+  await listEntryID(rtx, {startAtID: {clientID: 'cid', id: 'b', foo: 'bar'}});
+});
+
+test('listIDs', async () => {
+  assertType<{clientID: string}[]>(await listIDsEntryNoID(rtx));
+  await listIDsEntryNoID(rtx, {});
+  await listIDsEntryNoID(rtx, {limit: 1});
+  await listIDsEntryNoID(rtx, {startAtID: {clientID: 'cid'}});
+  await listIDsEntryNoID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  // @ts-expect-error unknown property foo
+  await listIDsEntryNoID(rtx, {startAtID: {clientID: 'cid', foo: 'bar'}});
+  // @ts-expect-error unknown property id
+  await listIDsEntryNoID(rtx, {startAtID: {clientID: 'cid', id: 'bar'}});
+
+  assertType<{clientID: string; id: string}[]>(await listIDsEntryID(rtx));
+  await listIDsEntryID(rtx, {});
+  await listIDsEntryID(rtx, {limit: 1});
+  await listIDsEntryID(rtx, {startAtID: {clientID: 'cid'}});
+  await listIDsEntryID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  await listIDsEntryID(rtx, {startAtID: {clientID: 'cid', id: 'b'}});
+  await listIDsEntryID(rtx, {
+    // @ts-expect-error unknown property foo
+    startAtID: {clientID: 'cid', id: 'b', foo: 'bar'},
+  });
+});
+
+test('listClientIDs', async () => {
+  assertType<string[]>(await listClientIDsEntryNoID(rtx));
+  await listClientIDsEntryNoID(rtx, {});
+  await listClientIDsEntryNoID(rtx, {limit: 1});
+  await listClientIDsEntryNoID(rtx, {startAtID: {clientID: 'cid'}});
+  await listClientIDsEntryNoID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  // @ts-expect-error unknown property foo
+  await listClientIDsEntryNoID(rtx, {startAtID: {clientID: 'cid', foo: 'bar'}});
+  // @ts-expect-error unknown property id
+  await listClientIDsEntryNoID(rtx, {startAtID: {clientID: 'cid', id: 'bar'}});
+
+  assertType<string[]>(await listClientIDsEntryID(rtx));
+  await listClientIDsEntryID(rtx, {});
+  await listClientIDsEntryID(rtx, {limit: 1});
+  await listClientIDsEntryID(rtx, {startAtID: {clientID: 'cid'}});
+  await listClientIDsEntryID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  await listClientIDsEntryID(rtx, {startAtID: {clientID: 'cid', id: 'b'}});
+  await listClientIDsEntryID(rtx, {
+    // @ts-expect-error unknown property foo
+    startAtID: {clientID: 'cid', id: 'b', foo: 'bar'},
+  });
+});
+
+test('listEntries', async () => {
+  assertType<[{clientID: string}, EntryNoID][]>(
+    await listEntriesEntryNoID(rtx),
+  );
+  await listEntriesEntryNoID(rtx, {});
+  await listEntriesEntryNoID(rtx, {limit: 1});
+  await listEntriesEntryNoID(rtx, {startAtID: {clientID: 'cid'}});
+  await listEntriesEntryNoID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  // @ts-expect-error unknown property foo
+  await listEntriesEntryNoID(rtx, {startAtID: {clientID: 'cid', foo: 'bar'}});
+  // @ts-expect-error unknown property id
+  await listEntriesEntryNoID(rtx, {startAtID: {clientID: 'cid', id: 'bar'}});
+
+  assertType<[{clientID: string; id: string}, EntryID][]>(
+    await listEntriesEntryID(rtx),
+  );
+  await listEntriesEntryID(rtx, {});
+  await listEntriesEntryID(rtx, {limit: 1});
+  await listEntriesEntryID(rtx, {startAtID: {clientID: 'cid'}});
+  await listEntriesEntryID(rtx, {startAtID: {clientID: 'cid'}, limit: 0});
+  await listEntriesEntryID(rtx, {startAtID: {clientID: 'cid', id: 'b'}});
+  await listEntriesEntryID(rtx, {
+    // @ts-expect-error unknown property foo
+    startAtID: {clientID: 'cid', id: 'b', foo: 'bar'},
+  });
+});

--- a/src/generate-presence.test.ts
+++ b/src/generate-presence.test.ts
@@ -6,7 +6,7 @@ import {MutatorDefs, Replicache, TEST_LICENSE_KEY} from 'replicache';
 import {expect, suite, test} from 'vitest';
 import {ZodError, z} from 'zod';
 import {
-  ListOptionsForPresence,
+  ListOptions,
   PresenceEntity,
   generatePresence,
   keyFromID,
@@ -1405,10 +1405,7 @@ suite('list', () => {
     name: string;
     collectionName: 'entryNoID' | 'entryID';
     stored: Record<string, ReadonlyJSONValue>;
-    param:
-      | ListOptionsForPresence<EntryID>
-      | ListOptionsForPresence<EntryNoID>
-      | undefined;
+    param: ListOptions<EntryID> | ListOptions<EntryNoID> | undefined;
     expectedValues: ReadonlyJSONValue[] | undefined;
     expectedError?: ReadonlyJSONValue;
   };
@@ -1631,10 +1628,7 @@ suite('listIDs', () => {
     name: string;
     collectionName: 'entryNoID' | 'entryID';
     stored: Record<string, ReadonlyJSONValue>;
-    param:
-      | ListOptionsForPresence<EntryID>
-      | ListOptionsForPresence<EntryNoID>
-      | undefined;
+    param: ListOptions<EntryID> | ListOptions<EntryNoID> | undefined;
     expectedValues: ReadonlyJSONValue[] | undefined;
     expectedError?: ReadonlyJSONValue;
   };
@@ -1849,10 +1843,7 @@ suite('listClientIDs', () => {
     name: string;
     collectionName: 'entryNoID' | 'entryID';
     stored: Record<string, ReadonlyJSONValue>;
-    param:
-      | ListOptionsForPresence<EntryID>
-      | ListOptionsForPresence<EntryNoID>
-      | undefined;
+    param: ListOptions<EntryID> | ListOptions<EntryNoID> | undefined;
     expectedValues: ReadonlyJSONValue[] | undefined;
     expectedError?: ReadonlyJSONValue;
   };
@@ -2034,10 +2025,7 @@ suite('listEntries', () => {
     name: string;
     collectionName: 'entryNoID' | 'entryID';
     stored: Record<string, ReadonlyJSONValue>;
-    param:
-      | ListOptionsForPresence<EntryID>
-      | ListOptionsForPresence<EntryNoID>
-      | undefined;
+    param: ListOptions<EntryID> | ListOptions<EntryNoID> | undefined;
     expectedValues: ReadonlyJSONValue[] | undefined;
     expectedError?: ReadonlyJSONValue;
   };

--- a/src/generate-presence.test.ts
+++ b/src/generate-presence.test.ts
@@ -1844,7 +1844,7 @@ suite('listIDs', () => {
   }
 });
 
-suite.only('listClientIDs', () => {
+suite('listClientIDs', () => {
   type Case = {
     name: string;
     collectionName: 'entryNoID' | 'entryID';
@@ -2307,7 +2307,7 @@ suite('listEntries', () => {
   }
 });
 
-test('optionalLogger', async () => {
+suite('optionalLogger', () => {
   type Case = {
     name: string;
     logger: OptionalLogger | undefined;
@@ -2340,7 +2340,7 @@ test('optionalLogger', async () => {
         },
       },
       expected: clientID => [
-        `no such entity {"clientID":"${clientID}","id":"a"}, skipping update`,
+        `no such entity {"clientID":"${clientID}"}, skipping update`,
       ],
     },
   ];
@@ -2349,18 +2349,20 @@ test('optionalLogger', async () => {
 
   for (const f of factories) {
     for (const c of cases) {
-      const {update: updateEntryNoID} = generatePresence(
-        name,
-        entryNoID.parse,
-        c.logger,
-      );
-      output = undefined;
+      test(c.name, async () => {
+        const {update: updateEntryNoID} = generatePresence(
+          name,
+          entryNoID.parse,
+          c.logger,
+        );
+        output = undefined;
 
-      const r = f({updateEntryNoID});
-      const clientID = await r.clientID;
+        const r = f({updateEntryNoID});
+        const clientID = await r.clientID;
 
-      await r.mutate.updateEntryNoID({clientID, str: 'bar'});
-      expect(output, c.name).toEqual(c.expected?.(clientID));
+        await r.mutate.updateEntryNoID({clientID, str: 'bar'});
+        expect(output).toEqual(c.expected?.(clientID));
+      });
     }
   }
 });

--- a/src/generate-presence.ts
+++ b/src/generate-presence.ts
@@ -135,7 +135,7 @@ export type GeneratePresenceResult<T extends PresenceEntity> = {
 const presencePrefix = '-/p/';
 
 export function keyFromID(name: string, entity: PresenceEntity) {
-  const {clientID, id} = entity as {clientID: string; id?: string};
+  const {clientID, id} = entity;
   if (id !== undefined) {
     return `${presencePrefix}${clientID}/${name}/id/${id}`;
   }
@@ -334,7 +334,7 @@ export function generatePresence<T extends PresenceEntity>(
         parseKeyToIDLocal,
         firstKey,
         tx,
-        normalizeScanOptions(options) as ListOptionsWith<ListID<T>>,
+        normalizeScanOptions(options),
       ),
     listClientIDs: (tx, options?) =>
       listClientIDsImpl(
@@ -342,7 +342,7 @@ export function generatePresence<T extends PresenceEntity>(
         parseKeyToIDLocal,
         firstKey,
         tx,
-        normalizeScanOptions(options) as ListOptionsWith<ListID<T>>,
+        normalizeScanOptions(options),
       ),
     listEntries: (tx, options?) =>
       listEntriesImpl(

--- a/src/generate-presence.ts
+++ b/src/generate-presence.ts
@@ -73,12 +73,12 @@ export type OptionalClientID<T extends PresenceEntity> = {
   clientID?: string | undefined;
 } & Omit<T, 'clientID'>;
 
-export type ListOptionsForPresence<T extends PresenceEntity> = {
+export type ListOptions<T extends PresenceEntity> = {
   startAtID?: StartAtID<T>;
   limit?: number;
 };
 
-type Update<T extends PresenceEntity> =
+export type Update<T extends PresenceEntity> =
   IsIDMissing<T> extends false ? Pick<T, 'id'> & Partial<T> : Partial<T>;
 
 export type GeneratePresenceResult<T extends PresenceEntity> = {
@@ -102,10 +102,7 @@ export type GeneratePresenceResult<T extends PresenceEntity> = {
   /** Get value by ID, or throw if none exists. */
   mustGet: (tx: ReadTransaction, id?: PresenceID<T>) => Promise<T>;
   /** List values matching criteria. */
-  list: (
-    tx: ReadTransaction,
-    options?: ListOptionsForPresence<T>,
-  ) => Promise<T[]>;
+  list: (tx: ReadTransaction, options?: ListOptions<T>) => Promise<T[]>;
 
   /**
    * List ids matching criteria. Here the id is `{clientID: string}` if the
@@ -113,7 +110,7 @@ export type GeneratePresenceResult<T extends PresenceEntity> = {
    */
   listIDs: (
     tx: ReadTransaction,
-    options?: ListOptionsForPresence<T>,
+    options?: ListOptions<T>,
   ) => Promise<ListID<T>[]>;
 
   /**
@@ -122,13 +119,13 @@ export type GeneratePresenceResult<T extends PresenceEntity> = {
    */
   listClientIDs: (
     tx: ReadTransaction,
-    options?: ListOptionsForPresence<T>,
+    options?: ListOptions<T>,
   ) => Promise<string[]>;
 
   /** List [id, value] entries matching criteria. */
   listEntries: (
     tx: ReadTransaction,
-    options?: ListOptionsForPresence<T>,
+    options?: ListOptions<T>,
   ) => Promise<[ListID<T>, T][]>;
 };
 
@@ -225,7 +222,7 @@ function normalizeForSet<
 }
 
 export function normalizeScanOptions<T extends PresenceEntity>(
-  options?: ListOptionsForPresence<T>,
+  options?: ListOptions<T>,
 ): ListOptionsWith<ListID<T>> | undefined {
   if (!options) {
     return options;

--- a/src/generate-presence.ts
+++ b/src/generate-presence.ts
@@ -1,14 +1,14 @@
 import {OptionalLogger} from '@rocicorp/logger';
 import {
+  FirstKeyFunc,
   IDFromEntityFunc,
   KeyFromEntityFunc,
   KeyFromLookupIDFunc,
   KeyToIDFunc,
-  ListOptionsWithLookupID,
+  ListOptionsWith,
   Parse,
   ParseInternal,
   ReadTransaction,
-  Update,
   WriteTransaction,
   deleteImpl,
   getImpl,
@@ -19,123 +19,196 @@ import {
   listImpl,
   maybeParse,
   mustGetImpl,
+  scan,
   setImpl,
   updateImpl,
 } from './generate.js';
 
+/**
+ * For presence entities there are two common cases:
+ * 1. The entity does not have an `id` field. Then there can only be one entity
+ *    per client. This case is useful for keeping track of things like the
+ *    cursor position.
+ * 2. The entity has an `id` field. Then there can be multiple entities per
+ *    client. This case is useful for keeping track of things like multiple
+ *    selection or multiple cursors (aka multi touch).
+ */
 export type PresenceEntity = {
   clientID: string;
-  id: string;
+  id?: string;
 };
 
-/**
- * Like {@link PresenceEntity}, but with the fields optional. This is used when
- * doing get, has and delete operations where the clientID and id fields are
- * optional.
- */
-export type PresenceID = Partial<PresenceEntity>;
+type IsIDMissing<T> = 'id' extends keyof T ? false : true;
 
 /**
- * When mutating an entity, you can omit the `clientID` and `id` fields. This
- * type marks those fields as optional.
+ * Like {@link PresenceEntity}, but with the clientID optional. This is used
+ * when doing get, has and delete operations where the clientID field defaults
+ * to the current client.
  */
-export type OptionalIDs<T extends PresenceEntity> = PresenceID &
-  Omit<T, keyof PresenceEntity>;
+export type PresenceID<T extends PresenceEntity> =
+  IsIDMissing<T> extends false
+    ? {
+        clientID?: string;
+        id: string;
+      }
+    : {
+        clientID?: string;
+      };
 
-export type ListOptionsForPresence = ListOptionsWithLookupID<PresenceID>;
+export type StartAtID<T extends PresenceEntity> =
+  IsIDMissing<T> extends true ? {clientID: string} : PresenceEntity;
+
+type ListID<T extends PresenceEntity> =
+  IsIDMissing<T> extends true
+    ? {clientID: string}
+    : undefined extends T['id']
+      ? PresenceEntity
+      : {clientID: string; id: string};
+
+/**
+ * When mutating an entity, you can omit the `clientID`. This type marks that
+ * field as optional.
+ */
+export type OptionalClientID<T extends PresenceEntity> = {
+  clientID?: string | undefined;
+} & Omit<T, 'clientID'>;
+
+export type ListOptionsForPresence<T extends PresenceEntity> = {
+  startAtID?: StartAtID<T>;
+  limit?: number;
+};
+
+type Update<T extends PresenceEntity> =
+  IsIDMissing<T> extends false ? Pick<T, 'id'> & Partial<T> : Partial<T>;
 
 export type GeneratePresenceResult<T extends PresenceEntity> = {
   /** Write `value`, overwriting any previous version of same value. */
-  set: (tx: WriteTransaction, value: OptionalIDs<T>) => Promise<void>;
+  set: (tx: WriteTransaction, value: OptionalClientID<T>) => Promise<void>;
   /**
    * Write `value`, overwriting any previous version of same value.
    * @deprecated Use `set` instead.
    */
-  put: (tx: WriteTransaction, value: OptionalIDs<T>) => Promise<void>;
+  put: (tx: WriteTransaction, value: OptionalClientID<T>) => Promise<void>;
   /** Write `value` only if no previous version of this value exists. */
-  init: (tx: WriteTransaction, value: OptionalIDs<T>) => Promise<boolean>;
+  init: (tx: WriteTransaction, value: OptionalClientID<T>) => Promise<boolean>;
   /** Update existing value with new fields. */
-  update: (tx: WriteTransaction, value: Update<PresenceID, T>) => Promise<void>;
+  update: (tx: WriteTransaction, value: Update<T>) => Promise<void>;
   /** Delete any existing value or do nothing if none exist. */
-  delete: (tx: WriteTransaction, id?: PresenceID) => Promise<void>;
+  delete: (tx: WriteTransaction, id?: PresenceID<T>) => Promise<void>;
   /** Return true if specified value exists, false otherwise. */
-  has: (tx: ReadTransaction, id?: PresenceID) => Promise<boolean>;
+  has: (tx: ReadTransaction, id?: PresenceID<T>) => Promise<boolean>;
   /** Get value by ID, or return undefined if none exists. */
-  get: (tx: ReadTransaction, id?: PresenceID) => Promise<T | undefined>;
+  get: (tx: ReadTransaction, id?: PresenceID<T>) => Promise<T | undefined>;
   /** Get value by ID, or throw if none exists. */
-  mustGet: (tx: ReadTransaction, id?: PresenceID) => Promise<T>;
+  mustGet: (tx: ReadTransaction, id?: PresenceID<T>) => Promise<T>;
   /** List values matching criteria. */
-  list: (tx: ReadTransaction, options?: ListOptionsForPresence) => Promise<T[]>;
-  /** List ids matching criteria. */
+  list: (
+    tx: ReadTransaction,
+    options?: ListOptionsForPresence<T>,
+  ) => Promise<T[]>;
+
+  /**
+   * List ids matching criteria. Here the id is `{clientID: string}` if the
+   * entry has no `id` field, otherwise it is `{clientID: string, id: string}`.
+   */
   listIDs: (
     tx: ReadTransaction,
-    options?: ListOptionsForPresence,
-  ) => Promise<PresenceEntity[]>;
+    options?: ListOptionsForPresence<T>,
+  ) => Promise<ListID<T>[]>;
+
+  /**
+   * List clientIDs matching criteria. Unlike listIDs this returns an array of strings
+   * consisting of the clientIDs
+   */
+  listClientIDs: (
+    tx: ReadTransaction,
+    options?: ListOptionsForPresence<T>,
+  ) => Promise<string[]>;
+
   /** List [id, value] entries matching criteria. */
   listEntries: (
     tx: ReadTransaction,
-    options?: ListOptionsForPresence,
-  ) => Promise<[PresenceEntity, T][]>;
+    options?: ListOptionsForPresence<T>,
+  ) => Promise<[ListID<T>, T][]>;
 };
 
 const presencePrefix = '-/p/';
 
-function keyFromID(name: string, entity: PresenceEntity) {
-  const {clientID, id} = entity;
-  return `${presencePrefix}${clientID}/${name}/${id}`;
+export function keyFromID(name: string, entity: PresenceEntity) {
+  const {clientID, id} = entity as {clientID: string; id?: string};
+  if (id !== undefined) {
+    return `${presencePrefix}${clientID}/${name}/id/${id}`;
+  }
+  return `${presencePrefix}${clientID}/${name}/`;
 }
 
 export function parseKeyToID(
   name: string,
   key: string,
-): PresenceEntity | undefined {
+): {clientID: string} | {clientID: string; id: string} | undefined {
   const parts = key.split('/');
   if (
-    parts.length !== 5 ||
+    parts.length < 5 ||
     parts[0] !== '-' ||
     parts[1] !== 'p' ||
     parts[2] === '' || // clientID
-    parts[3] !== name
+    parts[3] !== name ||
+    (parts[4] !== 'id' && parts[4] !== '')
   ) {
     return undefined;
   }
-  return {clientID: parts[2], id: parts[4]};
+
+  // Now we know the key starts with '-/p/{clientID}/name/' or '-/p/{clientID}/name/id/{id}'
+  if (parts.length === 5 && parts[4] === '') {
+    return {clientID: parts[2]};
+  }
+  if (parts.length === 6 && parts[4] === 'id') {
+    return {clientID: parts[2], id: parts[5]};
+  }
+
+  return undefined;
 }
 
 const idFromEntity: IDFromEntityFunc<PresenceEntity, PresenceEntity> = (
   _tx: ReadTransaction,
   entity: PresenceEntity,
-) => ({clientID: entity.clientID, id: entity.id});
+) =>
+  entity.id === undefined
+    ? {clientID: entity.clientID}
+    : {clientID: entity.clientID, id: entity.id};
 
-function normalizePresenceID(
+function normalizePresenceID<T extends PresenceEntity>(
   tx: {clientID: string},
   base: Partial<PresenceEntity> | undefined,
-) {
-  if (base === undefined) {
-    return {clientID: tx.clientID, id: ''};
+): ListID<T> {
+  // When we replay mutations (delete in this case) undefined arguments gets converted to null.
+  //
+  //   deleteEntity()
+  //
+  // becomes:
+  //
+  //   deleteEntity(null)
+  //
+  // when rebasing.
+  // eslint-disable-next-line eqeqeq
+  if (base == null) {
+    return {clientID: tx.clientID} as ListID<T>;
   }
-  return {
-    clientID: base.clientID ?? tx.clientID,
-    id: base.id ?? '',
-  };
+  const {clientID = tx.clientID, id} = base;
+  return (id === undefined ? {clientID} : {clientID, id}) as ListID<T>;
 }
 
-function normalizeUpdate<T extends {id?: string | undefined}>(
+function normalizeForUpdate<T extends PresenceEntity>(
   tx: {clientID: string},
-  update: T,
-): T & PresenceEntity {
-  validateMutate(tx, update);
-  return {
-    ...update,
-    clientID: tx.clientID,
-    id: update.id ?? '',
-  };
+  v: Update<T>,
+): Update<T> & {clientID: string} {
+  return normalizeForSet(tx, v);
 }
 
-function normalizeForSet<V extends PresenceID>(
-  tx: {clientID: string},
-  v: V,
-): V & PresenceEntity {
+function normalizeForSet<
+  T extends PresenceEntity,
+  V extends OptionalClientID<T>,
+>(tx: {clientID: string}, v: V): V & {clientID: string} {
   if (v === null) {
     throw new TypeError('Expected object, received null');
   }
@@ -145,33 +218,31 @@ function normalizeForSet<V extends PresenceID>(
 
   validateMutate(tx, v);
 
-  type R = V & PresenceEntity;
-
-  if (v.clientID === undefined && v.id === undefined) {
-    return {...v, clientID: tx.clientID, id: ''};
+  if ('clientID' in v) {
+    return v as V & {clientID: string};
   }
-  if (v.id === undefined) {
-    return {...v, id: ''} as R;
-  }
-  if (v.clientID === undefined) {
-    return {...v, clientID: tx.clientID} as R;
-  }
-
-  return v as R;
+  return {...v, clientID: tx.clientID};
 }
 
-export function normalizeScanOptions(options?: ListOptionsForPresence) {
+export function normalizeScanOptions<T extends PresenceEntity>(
+  options?: ListOptionsForPresence<T>,
+): ListOptionsWith<ListID<T>> | undefined {
   if (!options) {
     return options;
   }
   const {startAtID, limit} = options;
   return {
-    startAtID: startAtID && normalizePresenceID({clientID: ''}, startAtID),
+    startAtID:
+      startAtID &&
+      (normalizePresenceID({clientID: ''}, startAtID) as ListID<T>),
     limit,
   };
 }
 
-function validateMutate(tx: {clientID: string}, id: PresenceID): void {
+function validateMutate(
+  tx: {clientID: string},
+  id: {clientID?: string | undefined},
+): void {
   if (id.clientID && id.clientID !== tx.clientID) {
     throw new Error(
       `Can only mutate own entities. Expected clientID "${tx.clientID}" but received "${id.clientID}"`,
@@ -179,6 +250,16 @@ function validateMutate(tx: {clientID: string}, id: PresenceID): void {
   }
 }
 
+export function generatePresence<T extends Required<PresenceEntity>>(
+  name: string,
+  parse?: Parse<T> | undefined,
+  logger?: OptionalLogger,
+): GeneratePresenceResult<T>;
+export function generatePresence<T extends PresenceEntity>(
+  name: string,
+  parse?: Parse<T> | undefined,
+  logger?: OptionalLogger,
+): GeneratePresenceResult<T>;
 export function generatePresence<T extends PresenceEntity>(
   name: string,
   parse: Parse<T> | undefined = undefined,
@@ -192,12 +273,12 @@ export function generatePresence<T extends PresenceEntity>(
     keyFromID(name, entity);
   const keyFromIDLocal: KeyFromLookupIDFunc<PresenceEntity> = id =>
     keyFromID(name, id);
-  const parseKeyToIDLocal: KeyToIDFunc<PresenceEntity> = (key: string) =>
-    parseKeyToID(name, key);
+  const parseKeyToIDLocal: KeyToIDFunc<ListID<T>> = (key: string) =>
+    parseKeyToID(name, key) as ListID<T>;
   const firstKey = () => presencePrefix;
   const parseInternal: ParseInternal<T> = (_, v) => maybeParse(parse, v);
   const parseAndValidateClientIDForMutate: ParseInternal<T> = (tx, v) =>
-    parseInternal(tx, normalizeForSet(tx, v as OptionalIDs<PresenceEntity>));
+    parseInternal(tx, normalizeForSet(tx, v as unknown as OptionalClientID<T>));
   const set: GeneratePresenceResult<T>['set'] = (tx, value) =>
     setImpl(keyFromEntityLocal, parseAndValidateClientIDForMutate, tx, value);
 
@@ -215,22 +296,23 @@ export function generatePresence<T extends PresenceEntity>(
       updateImpl(
         keyFromEntityLocal,
         idFromEntity,
+        parseInternal,
         parseAndValidateClientIDForMutate,
         tx,
-        normalizeUpdate(tx, update),
+        normalizeForUpdate(tx, update),
         logger,
       ),
-    delete: (tx, id) =>
+    delete: (tx, id?) =>
       deleteImpl(
         keyFromIDLocal,
         validateMutate,
         tx,
         normalizePresenceID(tx, id),
       ),
-    has: (tx, id) => hasImpl(keyFromIDLocal, tx, normalizePresenceID(tx, id)),
-    get: (tx, id) =>
+    has: (tx, id?) => hasImpl(keyFromIDLocal, tx, normalizePresenceID(tx, id)),
+    get: (tx, id?) =>
       getImpl(keyFromIDLocal, parseInternal, tx, normalizePresenceID(tx, id)),
-    mustGet: (tx, id) =>
+    mustGet: (tx, id?) =>
       mustGetImpl(
         keyFromIDLocal,
         parseInternal,
@@ -247,12 +329,20 @@ export function generatePresence<T extends PresenceEntity>(
         normalizeScanOptions(options),
       ),
     listIDs: (tx, options?) =>
-      listIDsImpl(
+      listIDsImpl<ListID<T>>(
         keyFromIDLocal,
         parseKeyToIDLocal,
         firstKey,
         tx,
-        normalizeScanOptions(options),
+        normalizeScanOptions(options) as ListOptionsWith<ListID<T>>,
+      ),
+    listClientIDs: (tx, options?) =>
+      listClientIDsImpl(
+        keyFromIDLocal,
+        parseKeyToIDLocal,
+        firstKey,
+        tx,
+        normalizeScanOptions(options) as ListOptionsWith<ListID<T>>,
       ),
     listEntries: (tx, options?) =>
       listEntriesImpl(
@@ -264,4 +354,49 @@ export function generatePresence<T extends PresenceEntity>(
         normalizeScanOptions(options),
       ),
   };
+}
+
+async function listClientIDsImpl<ID extends PresenceEntity>(
+  keyFromID: KeyFromLookupIDFunc<ID>,
+  keyToID: KeyToIDFunc<ID>,
+  firstKey: FirstKeyFunc,
+  tx: ReadTransaction,
+  options?: ListOptionsWith<ID>,
+): Promise<string[]> {
+  // For this function we might get more than one entry per clientID in case there are entries like:
+  //
+  //   -/p/clientID1/name/id/id1
+  //   -/p/clientID1/name/id/id2
+  //   -/p/clientID1/name/id/id3
+  //
+  // We therefore remove the limit passed into scan and manage the limit ourselves.
+  // We also need to make sure we don't return the same clientID twice.
+
+  const result: string[] = [];
+  const keyToID2 = (key: string): string | undefined => {
+    const id = keyToID(key);
+    return id?.clientID;
+  };
+  let last = undefined;
+  const fixedOptions = {
+    ...options,
+    limit: undefined,
+  };
+  let {limit: i = Infinity} = options ?? {};
+  for await (const [k] of scan(
+    keyFromID,
+    keyToID2,
+    firstKey,
+    tx,
+    fixedOptions,
+  )) {
+    if (k !== last) {
+      if (--i < 0) {
+        break;
+      }
+      last = k;
+      result.push(k);
+    }
+  }
+  return result;
 }

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -445,6 +445,13 @@ suite('update', () => {
       expected: {id, str: 'baz', optStr: 'bar'},
       expectError: undefined,
     },
+    {
+      name: 'valid-update, no str',
+      prev: {id, str: 'foo', optStr: 'bar'},
+      update: {id},
+      expected: {id, str: 'foo', optStr: 'bar'},
+      expectError: undefined,
+    },
   ];
 
   for (const f of factories) {

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -532,6 +532,7 @@ suite('list', () => {
     name: string;
     prefix: string;
     schema: ZodTypeAny;
+    stored: Record<string, ReadonlyJSONValue>;
     options?: ListOptions | undefined;
     expected?: ReadonlyJSONValue[] | undefined;
     expectError?: ReadonlyJSONValue | undefined;
@@ -542,6 +543,12 @@ suite('list', () => {
       name: 'all',
       prefix: 'e1',
       schema: e1,
+      stored: {
+        'e1-not-an-entity': 'not an entity',
+        'e1/foo': {id: 'foo', str: 'foostr'},
+        'e1/bar': {id: 'bar', str: 'barstr'},
+        'e1/baz': {id: 'baz', str: 'bazstr'},
+      },
       expected: [
         {id: 'bar', str: 'barstr'},
         {id: 'baz', str: 'bazstr'},
@@ -553,6 +560,12 @@ suite('list', () => {
       name: 'keystart',
       prefix: 'e1',
       schema: e1,
+      stored: {
+        'a': 'not an entity',
+        'e1/foo': {id: 'foo', str: 'foostr'},
+        'e1/bar': {id: 'bar', str: 'barstr'},
+        'e1/baz': {id: 'baz', str: 'bazstr'},
+      },
       options: {
         startAtID: 'f',
       },
@@ -563,6 +576,12 @@ suite('list', () => {
       name: 'keystart+limit',
       prefix: 'e1',
       schema: e1,
+      stored: {
+        'e1/foo': {id: 'foo', str: 'foostr'},
+        'e1/bar': {id: 'bar', str: 'barstr'},
+        'e1/baz': {id: 'baz', str: 'bazstr'},
+        'e11': 'not an entity',
+      },
       options: {
         startAtID: 'bas',
         limit: 1,
@@ -577,18 +596,9 @@ suite('list', () => {
       test(c.name, async () => {
         const r = f(mutators);
 
-        await r.mutate.directWrite({
-          key: `e1/foo`,
-          val: {id: 'foo', str: 'foostr'},
-        });
-        await r.mutate.directWrite({
-          key: `e1/bar`,
-          val: {id: 'bar', str: 'barstr'},
-        });
-        await r.mutate.directWrite({
-          key: `e1/baz`,
-          val: {id: 'baz', str: 'bazstr'},
-        });
+        for (const [key, val] of Object.entries(c.stored)) {
+          await r.mutate.directWrite({key, val});
+        }
 
         let error = undefined;
         let actual = undefined;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -120,7 +120,7 @@ export function generate<T extends Entity>(
   const keyToID = (key: string) => id(prefix, key);
   const idFromEntity: IDFromEntityFunc<Entity, string> = (_tx, entity) =>
     entity.id;
-  const firstKey = () => prefix;
+  const firstKey = () => key(prefix, '');
   const parseInternal: ParseInternal<T> = (_, val) => maybeParse(parse, val);
   const set: GenerateResult<T>['set'] = (tx, value) =>
     setImpl(keyFromEntity, parseInternal, tx, value);

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -8,7 +8,9 @@ export type Entity = {
   id: string;
 };
 
-export type Update<Entity, T> = Entity & Partial<T>;
+export type Update<T> = Entity & Partial<T>;
+
+type UpdateWith<Entity, T> = Entity & Partial<T>;
 
 /**
  * A function that can parse a JSON value into a specific type.
@@ -83,7 +85,7 @@ export type GenerateResult<T extends Entity> = {
   /** Write `value` only if no previous version of this value exists. */
   init: (tx: WriteTransaction, value: T) => Promise<boolean>;
   /** Update existing value with new fields. */
-  update: (tx: WriteTransaction, value: Update<Entity, T>) => Promise<void>;
+  update: (tx: WriteTransaction, value: Update<T>) => Promise<void>;
   /** Delete any existing value or do nothing if none exist. */
   delete: (tx: WriteTransaction, id: string) => Promise<void>;
   /** Return true if specified value exists, false otherwise. */
@@ -250,7 +252,7 @@ export async function updateImpl<
   parseExisting: ParseInternal<Entity>,
   parseNew: ParseInternal<Entity>,
   tx: WriteTransaction,
-  update: Update<Entity, T>,
+  update: UpdateWith<Entity, T>,
   logger: OptionalLogger,
 ) {
   const k = keyFromEntity(tx, update);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 export {
   generatePresence,
   type GeneratePresenceResult,
-  type ListOptionsForPresence,
   type OptionalClientID,
   type PresenceEntity,
   type PresenceID,
+  type ListOptions as PresenceListOptions,
+  type Update as PresenceUpdate,
 } from './generate-presence.js';
 export {
   generate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export {
   generatePresence,
   type GeneratePresenceResult,
   type ListOptionsForPresence,
-  type OptionalIDs,
+  type OptionalClientID,
   type PresenceEntity,
   type PresenceID,
 } from './generate-presence.js';
@@ -12,7 +12,6 @@ export {
   type Entity,
   type GenerateResult,
   type ListOptions,
-  type ListOptionsWithLookupID,
   type Parse,
   type ReadTransaction,
   type ScanOptions,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,23 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
   test: {
-    onConsoleLog() {
-      return false;
+    onConsoleLog(log) {
+      if (
+        log.includes('Skipping license check for TEST_LICENSE_KEY.') ||
+        log.includes('REPLICACHE LICENSE NOT VALID') ||
+        log.includes('enableAnalytics false')
+      ) {
+        return false;
+      }
+    },
+    browser: {
+      enabled: true,
+      provider: 'playwright',
+      headless: true,
+      name: 'chromium',
+    },
+    typecheck: {
+      enabled: false,
     },
   },
 });


### PR DESCRIPTION
Now the keys that we store the presence entities allow distinguishing if there is an id with the value `''` vs no id provided. The keys used are:

```
-/p/${clientID}/${entityName}/
-/p/${clientID}/${entityName}/id/${id}
```

Then we also modify the types to not allow an `id` in the params passed to `get`, `list` `startAtID` etc if the type does not have an `id`.

We never add an `id` to an entity.
