### PR TITLE
ZQL: Generate query types and build the AST for all simple operators

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -833,7 +833,9 @@ test('undefined parse', async () => {
 
   const r = new Replicache({
     name: nanoid(),
-    mutators: generated,
+    mutators: {
+      set: generated.set,
+    },
     licenseKey: TEST_LICENSE_KEY,
   });
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -149,6 +149,7 @@ export function generate<T extends Entity>(
       listIDsImpl(keyFromID, keyToID, firstKey, tx, options),
     listEntries: (tx, options?) =>
       listEntriesImpl(keyFromID, keyToID, firstKey, parse, tx, options),
+    // query: () => new QueryInstance<{fields: T}>(),
   };
 }
 

--- a/src/zql/error/Misuse.ts
+++ b/src/zql/error/Misuse.ts
@@ -1,0 +1,1 @@
+export class Misuse extends Error {}

--- a/src/zql/query/EntityQueryInstance.test.ts
+++ b/src/zql/query/EntityQueryInstance.test.ts
@@ -1,0 +1,237 @@
+import {expect, expectTypeOf, test} from 'vitest';
+import {z} from 'zod';
+import {QueryInstance} from './EntityQueryInstance.js';
+import {Misuse} from '../error/Misuse.js';
+
+test('query types', () => {
+  const e1 = z.object({
+    id: z.string(),
+    str: z.string(),
+    optStr: z.string().optional(),
+  });
+
+  type E1 = z.infer<typeof e1>;
+
+  const q = new QueryInstance<{fields: E1}>();
+
+  // @ts-expect-error - selecting fields that do not exist in the schema is a type error
+  q.select('does-not-exist');
+
+  expectTypeOf(q.select).toBeCallableWith('id');
+  expectTypeOf(q.select).toBeCallableWith('str', 'optStr');
+
+  expectTypeOf(q.select('id', 'str').prepare().run()).toMatchTypeOf<
+    readonly {id: string; str: string}[]
+  >();
+  expectTypeOf(q.select('id').prepare().run()).toMatchTypeOf<
+    readonly {id: string}[]
+  >();
+  expectTypeOf(q.select('optStr').prepare().run()).toMatchTypeOf<
+    readonly {optStr?: string}[]
+  >();
+
+  // where/order/limit do not change return type
+  expectTypeOf(
+    q
+      .select('id', 'str')
+      .where('id', '<', '123')
+      .limit(1)
+      .asc('id')
+      .prepare()
+      .run(),
+  ).toMatchTypeOf<readonly {id: string; str: string}[]>();
+
+  expectTypeOf(q.where).toBeCallableWith('id', '=', 'foo');
+  expectTypeOf(q.where).toBeCallableWith('str', '<', 'foo');
+  expectTypeOf(q.where).toBeCallableWith('optStr', '>', 'foo');
+
+  // @ts-expect-error - comparing on missing fields is an error
+  q.where('does-not-exist', '=', 'x');
+
+  // @ts-expect-error - comparing with the wrong data type for the value is an error
+  q.where('id', '=', 1);
+
+  expectTypeOf(q.count().prepare().run()).toMatchTypeOf<number>();
+});
+
+const e1 = z.object({
+  id: z.string(),
+  a: z.number(),
+  b: z.bigint(),
+  c: z.string().optional(),
+  d: z.boolean(),
+});
+
+type E1 = z.infer<typeof e1>;
+const dummyObject: E1 = {
+  id: 'a',
+  a: 1,
+  b: 1n,
+  c: '',
+  d: true,
+};
+
+test('ast: select', () => {
+  const q = new QueryInstance<{fields: E1}>();
+
+  // each individual field is selectable on its own
+  Object.keys(dummyObject).forEach(k => {
+    const newq = q.select(k as keyof E1);
+    expect(newq._ast.select).toEqual([k]);
+  });
+
+  // all fields are selectable together
+  let newq = q.select(...(Object.keys(dummyObject) as (keyof E1)[]));
+  expect(newq._ast.select).toEqual(Object.keys(dummyObject));
+
+  // we can call select many times to build up the selection set
+  newq = q;
+  Object.keys(dummyObject).forEach(k => {
+    newq = newq.select(k as keyof E1);
+  });
+  expect(newq._ast.select).toEqual(Object.keys(dummyObject));
+
+  // we remove duplicates
+  newq = q;
+  Object.keys(dummyObject).forEach(k => {
+    newq = newq.select(k as keyof E1);
+  });
+  Object.keys(dummyObject).forEach(k => {
+    newq = newq.select(k as keyof E1);
+  });
+  expect(newq._ast.select).toEqual(Object.keys(dummyObject));
+});
+
+test('ast: count', () => {
+  // Cannot select fields in addition to a count.
+  // A query is one or the other: count query or selection query.
+  expect(() => new QueryInstance<{fields: E1}>().select('id').count()).toThrow(
+    Misuse,
+  );
+  expect(() => new QueryInstance<{fields: E1}>().count().select('id')).toThrow(
+    Misuse,
+  );
+
+  // selection set is the literal `count`, not an array of fields
+  const q = new QueryInstance<{fields: E1}>().count();
+  expect(q._ast.select).toEqual('count');
+});
+
+test('ast: where', () => {
+  let q = new QueryInstance<{fields: E1}>();
+
+  // where is applied
+  q = q.where('id', '=', 'a');
+
+  expect({...q._ast, alias: 0}).toEqual({
+    alias: 0,
+    where: [
+      {
+        field: 'id',
+        op: '=',
+        value: {
+          type: 'literal',
+          value: 'a',
+        },
+      },
+    ],
+  });
+
+  // additional wheres are anded
+  q = q.where('a', '>', 0);
+
+  expect({...q._ast, alias: 0}).toEqual({
+    alias: 0,
+    where: [
+      {
+        field: 'id',
+        op: '=',
+        value: {
+          type: 'literal',
+          value: 'a',
+        },
+      },
+      'AND',
+      {
+        field: 'a',
+        op: '>',
+        value: {
+          type: 'literal',
+          value: 0,
+        },
+      },
+    ],
+  });
+});
+
+test('ast: limit', () => {
+  const q = new QueryInstance<{fields: E1}>();
+  expect({...q.limit(10)._ast, alias: 0}).toEqual({
+    alias: 0,
+    limit: 10,
+  });
+});
+
+test('ast: asc/desc', () => {
+  // can only order once
+  const q = new QueryInstance<{fields: E1}>();
+  expect(() => q.asc('id').desc('id')).toThrow(Misuse);
+  expect(() => q.asc('id').asc('id')).toThrow(Misuse);
+  expect(() => q.desc('id').desc('id')).toThrow(Misuse);
+  expect(() => q.asc('id').desc('a')).toThrow(Misuse);
+
+  // order methods update the ast
+  expect({...q.asc('id')._ast, alias: 0}).toEqual({
+    alias: 0,
+    orderBy: [['id'], 'asc'],
+  });
+  expect({...q.desc('id')._ast, alias: 0}).toEqual({
+    alias: 0,
+    orderBy: [['id'], 'desc'],
+  });
+  expect({...q.asc('id', 'a', 'b', 'c', 'd')._ast, alias: 0}).toEqual({
+    alias: 0,
+    orderBy: [['id', 'a', 'b', 'c', 'd'], 'asc'],
+  });
+});
+
+test('ast: independent of method call order', () => {
+  const base = new QueryInstance<{fields: E1}>();
+
+  const calls = {
+    select(q: typeof base) {
+      return q.select('b');
+    },
+    where(q: typeof base) {
+      return q.where('c', 'LIKE', 'foo');
+    },
+    limit(q: typeof base) {
+      return q.limit(10);
+    },
+    asc(q: typeof base) {
+      return q.asc('a');
+    },
+  };
+
+  let q = base;
+  for (const call of Object.values(calls)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    q = call(q) as any;
+  }
+  const inOrderToAST = q._ast;
+
+  q = base;
+  for (const call of Object.values(calls).reverse()) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    q = call(q) as any;
+  }
+  const reverseToAST = q._ast;
+
+  expect({
+    ...inOrderToAST,
+    alias: 0,
+  }).toEqual({
+    ...reverseToAST,
+    alias: 0,
+  });
+});

--- a/src/zql/query/EntityQueryInstance.ts
+++ b/src/zql/query/EntityQueryInstance.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {Misuse} from '../error/Misuse.js';
+import {EntitySchema} from '../schema/EntitySchema.js';
+import {
+  MakeHumanReadable,
+  QueryInstanceType,
+  IStatement,
+  Selectable,
+  SelectedFields,
+} from './EntityQueryType.js';
+import {AST, Operator, Primitive} from './ZqlAst.js';
+
+let aliasCount = 0;
+
+export class QueryInstance<S extends EntitySchema, TReturn = []>
+  implements QueryInstanceType<S, TReturn>
+{
+  #ast: AST;
+
+  constructor(ast?: AST) {
+    this.#ast = ast ?? {
+      alias: aliasCount++,
+    };
+  }
+
+  select<Fields extends Selectable<S>[]>(...x: Fields) {
+    if (this.#ast.select === 'count') {
+      throw new Misuse(
+        'A query can either return fields or a count, not both.',
+      );
+    }
+
+    return new QueryInstance<S, SelectedFields<S['fields'], Fields>[]>({
+      ...this.#ast,
+      select: [...new Set([...(this.#ast.select || []), ...x])] as any,
+    });
+  }
+
+  where<K extends keyof S['fields']>(
+    field: K,
+    op: Operator,
+    value: S['fields'][K],
+  ) {
+    return new QueryInstance<S, TReturn>({
+      ...this.#ast,
+      where: [
+        ...(this.#ast.where !== undefined
+          ? [...this.#ast.where, 'AND' as const]
+          : []),
+        {
+          field: field as string,
+          op,
+          value: {
+            type: 'literal',
+            value: value as Primitive,
+          },
+        },
+      ],
+    });
+  }
+
+  limit(n: number) {
+    if (this.#ast.limit !== undefined) {
+      throw new Misuse('Limit already set');
+    }
+
+    return new QueryInstance<S, TReturn>({...this.#ast, limit: n});
+  }
+
+  asc(...x: (keyof S['fields'])[]) {
+    if (this.#ast.orderBy !== undefined) {
+      throw new Misuse('OrderBy already set');
+    }
+
+    return new QueryInstance<S, TReturn>({
+      ...this.#ast,
+      orderBy: [x as string[], 'asc'],
+    });
+  }
+
+  desc(...x: (keyof S['fields'])[]) {
+    if (this.#ast.orderBy !== undefined) {
+      throw new Misuse('OrderBy already set');
+    }
+
+    return new QueryInstance<S, TReturn>({
+      ...this.#ast,
+      orderBy: [x as string[], 'desc'],
+    });
+  }
+
+  count() {
+    if (this.#ast.select !== undefined) {
+      throw new Misuse(
+        'Selection set already set. Will not change to a count query.',
+      );
+    }
+    return new QueryInstance<S, number>({
+      ...this.#ast,
+      select: 'count',
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  get _ast() {
+    return this.#ast;
+  }
+
+  prepare() {
+    // TODO: build the IVM pipeline
+    return new Statement<TReturn>();
+  }
+}
+
+class Statement<TReturn> implements IStatement<TReturn> {
+  constructor() {}
+
+  run(): MakeHumanReadable<TReturn> {
+    // TODO run the query!
+    return {} as TReturn;
+  }
+}

--- a/src/zql/query/EntityQueryType.ts
+++ b/src/zql/query/EntityQueryType.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {EntitySchema} from '../schema/EntitySchema.js';
+import {Operator} from './ZqlAst.js';
+
+export type SelectedFields<T, Fields extends Selectable<any>[]> = Pick<
+  T,
+  Fields[number] extends keyof T ? Fields[number] : never
+>;
+
+export type Selectable<T extends EntitySchema> = keyof T['fields'];
+
+export type MakeHumanReadable<T> = {} & {
+  readonly [P in keyof T]: T[P] extends string ? T[P] : MakeHumanReadable<T[P]>;
+};
+
+export interface QueryInstanceType<TSchema extends EntitySchema, TReturn = []> {
+  readonly select: <Fields extends Selectable<TSchema>[]>(
+    ...x: Fields
+  ) => QueryInstanceType<TSchema, SelectedFields<TSchema['fields'], Fields>[]>;
+  readonly count: () => QueryInstanceType<TSchema, number>;
+  readonly where: <K extends keyof TSchema['fields']>(
+    f: K,
+    op: Operator,
+    value: TSchema['fields'][K],
+  ) => QueryInstanceType<TSchema, TReturn>;
+  readonly limit: (n: number) => QueryInstanceType<TSchema, TReturn>;
+  readonly asc: (
+    ...x: (keyof TSchema['fields'])[]
+  ) => QueryInstanceType<TSchema, TReturn>;
+  readonly desc: (
+    ...x: (keyof TSchema['fields'])[]
+  ) => QueryInstanceType<TSchema, TReturn>;
+
+  readonly prepare: () => IStatement<TReturn>;
+}
+
+export interface IStatement<TReturn> {
+  run: () => MakeHumanReadable<TReturn>;
+}

--- a/src/zql/query/ZqlAst.ts
+++ b/src/zql/query/ZqlAst.ts
@@ -1,0 +1,38 @@
+// Going for a subset of the SQL `SELECT` grammar
+// https://www.sqlite.org/lang_select.html
+
+export type Operator = '=' | '<' | '>' | '>=' | '<=' | 'IN' | 'LIKE' | 'ILIKE';
+export type Primitive = string | number | boolean | null | bigint;
+type Ref = `${string}.${string}`;
+export type AST = {
+  readonly table?: string;
+  readonly alias?: number;
+  readonly select?: string[] | 'count';
+  readonly subSelects?: {
+    readonly alias: string;
+    readonly query: AST;
+  }[];
+  readonly where?: ConditionList;
+  readonly joins?: {
+    readonly table: string;
+    readonly as: string;
+    readonly on: ConditionList;
+  }[];
+  readonly limit?: number;
+  readonly groupBy?: string[];
+  readonly orderBy?: [string[], 'asc' | 'desc'];
+  readonly after?: Primitive;
+};
+
+type Conjunction = 'AND' | 'OR' | 'NOT' | 'EXISTS';
+type ConditionList = (Conjunction | Condition)[];
+type Condition =
+  | ConditionList
+  | {
+      field: string;
+      op: Operator;
+      value: {
+        type: 'literal' | 'ref' | 'query';
+        value: Primitive | Ref | AST;
+      };
+    };

--- a/src/zql/schema/EntitySchema.ts
+++ b/src/zql/schema/EntitySchema.ts
@@ -1,0 +1,20 @@
+export type Edge<TSrc extends EntitySchema, TDst extends EntitySchema> = {
+  src: TSrc;
+  srcField: keyof TSrc['fields'];
+  dst: TDst;
+  dstField: keyof TDst['fields'];
+};
+
+export type Edges = {
+  [key: string]: Edge<EntitySchema, EntitySchema>;
+};
+export type Node = {
+  id: string;
+} & {
+  [key: string]: unknown;
+};
+
+export interface EntitySchema {
+  readonly fields: Node;
+  readonly edges?: Edges;
+}


### PR DESCRIPTION
Simple operators:
- select (only columns, no sub-queries)
- where (only AND and literal values, no sub-queries)
- limit
- orderBy
- count

Next step is to do IVM and get these simple operators working end to end.

After that we can think about join, sub-select, fragments, referencing parent queries, etc. etc.

----

See EntityQueryInstance.test.ts for example usage.