### PR TITLE
zql [2/n] - Hook Replicache up to ZQL

### DIFF
--- a/src/zql/ast/ast.ts
+++ b/src/zql/ast/ast.ts
@@ -4,7 +4,7 @@
 // TODO: the chosen operator needs to constrain the allowed values for the value
 // input to the query builder.
 export type Operator = '=' | '<' | '>' | '>=' | '<=' | 'IN' | 'LIKE' | 'ILIKE';
-
+export type Ordering = [string[], 'asc' | 'desc'];
 export type Primitive = string | number | boolean | null;
 // type Ref = `${string}.${string}`;
 export type AST = {
@@ -23,7 +23,7 @@ export type AST = {
   // }[];
   readonly limit?: number | undefined;
   // readonly groupBy?: string[];
-  readonly orderBy?: [string[], 'asc' | 'desc'] | undefined;
+  readonly orderBy?: Ordering | undefined;
   // readonly after?: Primitive;
 };
 

--- a/src/zql/context/context.ts
+++ b/src/zql/context/context.ts
@@ -8,7 +8,6 @@ export type Context = {
     name: string,
     ordering?: [string[], 'asc' | 'desc'],
   ) => Source<T>;
-  destroy: () => void;
 };
 
 export function makeTestContext(): Context {
@@ -20,24 +19,5 @@ export function makeTestContext(): Context {
     }
     return sources.get(name)! as Source<T>;
   };
-  return {materialite, getSource, destroy() {}};
+  return {materialite, getSource};
 }
-
-// const replicacheContexts = new Map<string, Context>();
-// export function getReplicacheContext(tx: ReadTransaction): Context {
-//   let existing = replicacheContexts.get(tx.clientID);
-//   if (!existing) {
-//     existing = {
-//       materialite: new Materialite(),
-//       getSource: (name, _ordering?: [string[], 'asc' | 'desc']) => {
-//         throw new Error(`Source not found: ${name}`);
-//       },
-//       destroy() {
-//         replicacheContexts.delete(tx.clientID);
-//       },
-//     };
-//     replicacheContexts.set(tx.clientID, existing);
-//   }
-
-//   return existing;
-// }

--- a/src/zql/context/replicache-context.test.ts
+++ b/src/zql/context/replicache-context.test.ts
@@ -1,0 +1,150 @@
+import {expect, test} from 'vitest';
+import {z} from 'zod';
+import {generate} from '../../generate.js';
+import {Replicache, TEST_LICENSE_KEY} from 'replicache';
+import {nanoid} from 'nanoid';
+import {makeReplicacheContext} from './replicache-context.js';
+import {SetSource} from '../ivm/source/set-source.js';
+import {EntityQuery} from '../query/entity-query.js';
+
+const e1 = z.object({
+  id: z.string(),
+  str: z.string(),
+  optStr: z.string().optional(),
+});
+
+type E1 = z.infer<typeof e1>;
+
+const {
+  init: initE1,
+  set: setE1,
+  update: updateE1,
+  delete: deleteE1,
+} = generate<E1>('e1', e1.parse);
+
+const mutators = {
+  initE1,
+  setE1,
+  updateE1,
+  deleteE1,
+};
+
+const newRep = () =>
+  new Replicache({
+    licenseKey: TEST_LICENSE_KEY,
+    name: nanoid(),
+    mutators,
+  });
+
+test('getSource - no ordering', async () => {
+  const r = newRep();
+  const context = makeReplicacheContext(r);
+  const source = context.getSource('e1');
+  expect(source).toBeDefined();
+
+  await r.mutate.initE1({id: '1', str: 'a'});
+  await r.mutate.initE1({id: '3', str: 'a'});
+  await r.mutate.initE1({id: '2', str: 'a'});
+
+  // source is ordered by id
+  expect([...(source as SetSource<E1>).value]).toEqual([
+    {id: '1', str: 'a'},
+    {id: '2', str: 'a'},
+    {id: '3', str: 'a'},
+  ]);
+
+  await r.mutate.deleteE1('1');
+
+  expect([...(source as SetSource<E1>).value]).toEqual([
+    {id: '2', str: 'a'},
+    {id: '3', str: 'a'},
+  ]);
+
+  await r.mutate.updateE1({id: '3', str: 'z'});
+
+  expect([...(source as SetSource<E1>).value]).toEqual([
+    {id: '2', str: 'a'},
+    {id: '3', str: 'z'},
+  ]);
+});
+
+test('getSource - with ordering', async () => {
+  const r = newRep();
+  const context = makeReplicacheContext(r);
+  const source = context.getSource('e1', [['str', 'id'], 'asc']);
+
+  await r.mutate.initE1({id: '1', str: 'c'});
+  await r.mutate.initE1({id: '3', str: 'z'});
+  await r.mutate.initE1({id: '2', str: 'a'});
+
+  expect([...(source as SetSource<E1>).value]).toEqual([
+    {id: '2', str: 'a'},
+    {id: '1', str: 'c'},
+    {id: '3', str: 'z'},
+  ]);
+
+  const sourceDesc = context.getSource('e1', [['str', 'id'], 'desc']);
+  // asc/desc don't matter. For desc we just iterate the asc collection backwards.
+  expect(source).toBe(sourceDesc);
+
+  await r.mutate.deleteE1('1');
+  await r.mutate.deleteE1('3');
+
+  expect([...(source as SetSource<E1>).value]).toEqual([{id: '2', str: 'a'}]);
+
+  await r.mutate.updateE1({id: '2', str: 'z'});
+
+  expect([...(source as SetSource<E1>).value]).toEqual([{id: '2', str: 'z'}]);
+});
+
+test('derived sources are correctly seeded', async () => {
+  const r = newRep();
+  const context = makeReplicacheContext(r);
+
+  await r.mutate.initE1({id: '1', str: 'c'});
+  await r.mutate.initE1({id: '3', str: 'z'});
+  await r.mutate.initE1({id: '2', str: 'a'});
+
+  const s1 = context.getSource('e1', [['str', 'id'], 'asc']);
+  const s2 = context.getSource('e1');
+
+  // go on to the next tick of the event loop
+  // so our read to load the source can complete.
+  // Maybe we need something on the source to expose
+  // whether or not it is done seeding.
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 0);
+  });
+
+  expect([...(s1 as SetSource<E1>).value]).toEqual([
+    {id: '2', str: 'a'},
+    {id: '1', str: 'c'},
+    {id: '3', str: 'z'},
+  ]);
+  expect([...(s2 as SetSource<E1>).value]).toEqual([
+    {id: '1', str: 'c'},
+    {id: '2', str: 'a'},
+    {id: '3', str: 'z'},
+  ]);
+});
+
+// Here as a sanity check for now.
+// Full e2e integration test suite will be in `zql/index.test.ts`
+test('ZQL query with Replicache', async () => {
+  const r = newRep();
+  const context = makeReplicacheContext(r);
+
+  const q = new EntityQuery<{fields: E1}>(context, 'e1');
+
+  const view = q.select('id').where('str', '>', 'm').prepare().materialize();
+
+  await Promise.all([
+    r.mutate.initE1({id: '1', str: 'c'}),
+    r.mutate.initE1({id: '3', str: 'z'}),
+    r.mutate.initE1({id: '2', str: 'a'}),
+    r.mutate.initE1({id: '4', str: 'x'}),
+    r.mutate.initE1({id: '5', str: 'y'}),
+  ]);
+
+  expect(view.value).toEqual([{id: '5'}, {id: '4'}, {id: '3'}]);
+});

--- a/src/zql/context/replicache-context.ts
+++ b/src/zql/context/replicache-context.ts
@@ -1,0 +1,149 @@
+import {ExperimentalNoIndexDiff, Replicache} from 'replicache';
+import {Materialite} from '../ivm/materialite.js';
+import {Entity} from '../../generate.js';
+import {Source} from '../ivm/source/source.js';
+import {MutableSetSource} from '../ivm/source/set-source.js';
+import {InvariantViolation} from '../error/invariant-violation.js';
+import {compareEntityFields} from '../ivm/compare.js';
+
+export function makeReplicacheContext(rep: Replicache) {
+  const materialite = new Materialite();
+  const sourceStore = new ReplicacheSourceStore(rep, materialite);
+
+  return {
+    materialite,
+    getSource: <T extends Entity>(
+      name: string,
+      ordering?: [string[], 'asc' | 'desc'],
+    ) => sourceStore.getSource(name, ordering) as Source<T>,
+  };
+}
+
+/**
+ * Forwards Replicache changes to Materialite sources so they
+ * can be fed into any queries that may exist.
+ *
+ * Maintains derived orderings of sources as well.
+ *
+ * If someone runs a query that has an order-by we need to scan the entire collection
+ * in order to sort it.
+ * To save future work, we save the result of that sort and keep it up to date.
+ *
+ * This helps:
+ * 1. When revisting old queries that were sorted or paging through results
+ * 2. When many queries are sorted by the same field
+ * 3. When joining sources on a field that we have pre-sorted
+ *
+ * And shares the work between queries.
+ */
+class ReplicacheSourceStore {
+  readonly #rep: Replicache;
+  readonly #materialite: Materialite;
+  readonly #sources = new Map<string, ReplicacheSource>();
+
+  constructor(rep: Replicache, materialite: Materialite) {
+    this.#rep = rep;
+    this.#materialite = materialite;
+  }
+
+  getSource(name: string, ordering?: [string[], 'asc' | 'desc']) {
+    let source = this.#sources.get(name);
+    if (source === undefined) {
+      source = new ReplicacheSource(this.#rep, this.#materialite, name);
+      this.#sources.set(name, source);
+    }
+
+    return source.get(ordering);
+  }
+}
+
+class ReplicacheSource {
+  readonly #materialite;
+  readonly #sources: Map<string, Source<Entity>> = new Map();
+  readonly #canonicalSource: MutableSetSource<Entity>;
+
+  constructor(rep: Replicache, materialite: Materialite, name: string) {
+    this.#canonicalSource =
+      materialite.newSetSource<Entity>(canonicalComparator);
+    this.#materialite = materialite;
+    rep.experimentalWatch(this.#onReplicacheDiff, {
+      prefix: `${name}/`,
+      initialValuesInFirstDiff: true,
+    });
+  }
+
+  #onReplicacheDiff = (changes: ExperimentalNoIndexDiff) => {
+    this.#materialite.tx(() => {
+      for (const diff of changes) {
+        if ('oldValue' in diff) {
+          // This lookup of old was due to seeing `oldValue` values that did not match
+          // what was stored on the client when working on Repliear.
+          // `oldValue` not matching what is on the client is problematic
+          // if there are derived sources with orderings that depend on fields outside the id.
+          // E.g.,
+          // If a derived source is sorted by `modified_time`
+          // and the `oldValue` provided has a different `modified_time` we'll fail to remove
+          // the correct value from the derived source.
+          const old = this.#canonicalSource.get(diff.oldValue as Entity);
+          if (old === null) {
+            throw new InvariantViolation(
+              'oldValue not found in canonical source',
+            );
+          }
+          this.#canonicalSource.delete(old);
+          for (const derived of this.#sources.values()) {
+            derived.delete(old);
+          }
+        }
+        if ('newValue' in diff) {
+          this.#canonicalSource.add(diff.newValue as Entity);
+          for (const derived of this.#sources.values()) {
+            derived.add(diff.newValue as Entity);
+          }
+        }
+      }
+    });
+  };
+
+  get(ordering?: [string[], 'asc' | 'desc']) {
+    if (
+      ordering === undefined ||
+      ordering[0].length === 0 ||
+      (ordering[0].length === 1 && ordering[0][0] === 'id')
+    ) {
+      return this.#canonicalSource;
+    }
+
+    const [keys, _] = ordering;
+    // We do _not_ use the direction to derive a soure. We can iterate backwards for DESC.
+    const key = keys.join(',');
+    let derivation = this.#sources.get(key);
+    if (derivation === undefined) {
+      const comparator = makeComparator(keys);
+      derivation = this.#canonicalSource.withNewOrdering(comparator);
+      this.#sources.set(key, derivation);
+    }
+
+    return derivation;
+  }
+}
+
+const canonicalComparator = (l: Entity, r: Entity) =>
+  l.id < r.id ? -1 : l.id > r.id ? 1 : 0;
+
+function makeComparator(key: string[]) {
+  return <T extends Entity>(l: T, r: T) => {
+    for (const k of key) {
+      if (!(k in l) || !(k in r)) {
+        throw new InvariantViolation(`Key ${k} not found in entities`);
+      }
+      const lVal = l[k as unknown as keyof T];
+      const rVal = r[k as unknown as keyof T];
+      const comp = compareEntityFields(lVal, rVal);
+      if (comp !== 0) {
+        return comp;
+      }
+    }
+    return 0;
+  };
+}

--- a/src/zql/error/asserts.ts
+++ b/src/zql/error/asserts.ts
@@ -1,9 +1,10 @@
+export class InvariantViolation extends Error {}
+
 export function assert(b: unknown, msg = 'Assertion failed'): asserts b {
   if (!b) {
     throw new InvariantViolation(msg);
   }
 }
-export class InvariantViolation extends Error {}
 
 export function invariant(p: boolean, msg: string) {
   if (!p) {
@@ -17,4 +18,8 @@ export function must<T>(v: T | undefined | null, msg?: string): T {
     throw new InvariantViolation(msg ?? `Unexpected ${v} value`);
   }
   return v;
+}
+
+export function unreachable(): never {
+  throw new InvariantViolation('Unreachable');
 }

--- a/src/zql/ivm/compare.ts
+++ b/src/zql/ivm/compare.ts
@@ -1,0 +1,21 @@
+import {InvariantViolation} from '../error/invariant-violation.js';
+
+export function compareEntityFields<T>(lVal: T, rVal: T) {
+  if (lVal === rVal) {
+    return 0;
+  }
+  if (lVal === null || lVal === undefined) {
+    return -1;
+  }
+  if (rVal === null || rVal === undefined) {
+    return 1;
+  }
+  if (lVal < rVal) {
+    return -1;
+  }
+  if (lVal > rVal) {
+    return 1;
+  }
+
+  throw new InvariantViolation('Unreachable');
+}

--- a/src/zql/ivm/compare.ts
+++ b/src/zql/ivm/compare.ts
@@ -1,4 +1,4 @@
-import {InvariantViolation} from '../error/invariant-violation.js';
+import {unreachable} from '../error/asserts.js';
 
 export function compareEntityFields<T>(lVal: T, rVal: T) {
   if (lVal === rVal) {
@@ -17,5 +17,5 @@ export function compareEntityFields<T>(lVal: T, rVal: T) {
     return 1;
   }
 
-  throw new InvariantViolation('Unreachable');
+  unreachable();
 }

--- a/src/zql/ivm/source/set-source.ts
+++ b/src/zql/ivm/source/set-source.ts
@@ -98,7 +98,6 @@ export abstract class SetSource<T> implements Source<T> {
     this.#listeners.clear();
   }
 
-  // TODO: implement these correctly.
   on(cb: (value: ITree<T>, version: Version) => void): () => void {
     this.#listeners.add(cb);
     return () => this.#listeners.delete(cb);
@@ -119,12 +118,15 @@ export abstract class SetSource<T> implements Source<T> {
     this._materialite.addDirtySource(this.#internal);
     return this;
   }
+
+  get(key: T): T | null {
+    return this.#tree.get(key);
+  }
 }
 
 export class MutableSetSource<T> extends SetSource<T> {
   constructor(
     materialite: MaterialiteForSourceInternal,
-    // TODO: comarator is really only on the selected set of fields that participate in the `order-by`
     comparator: Comparator<T>,
   ) {
     super(materialite, comparator, comparator => new Treap(comparator));

--- a/src/zql/ivm/source/set-source.ts
+++ b/src/zql/ivm/source/set-source.ts
@@ -119,8 +119,12 @@ export abstract class SetSource<T> implements Source<T> {
     return this;
   }
 
-  get(key: T): T | null {
-    return this.#tree.get(key);
+  get(key: T): T | undefined {
+    const ret = this.#tree.get(key);
+    if (ret === null) {
+      return undefined;
+    }
+    return ret;
   }
 }
 

--- a/src/zql/query/statement.ts
+++ b/src/zql/query/statement.ts
@@ -9,6 +9,7 @@ import {ValueView} from '../ivm/view/primitive-view.js';
 import {Primitive} from '../ast/ast.js';
 import {Entity} from '../../generate.js';
 import {invariant} from '../error/asserts.js';
+import {compareEntityFields} from '../ivm/compare.js';
 
 export interface Statement<TReturn> {
   materialize: () => View<MakeHumanReadable<TReturn>>;
@@ -100,19 +101,9 @@ export function ascComparator<T extends {[orderingProp]: Primitive[]}>(
   for (let i = 0; i < leftVals.length; i++) {
     const leftVal = leftVals[i];
     const rightVal = rightVals[i];
-    if (leftVal === rightVal) {
-      continue;
-    }
-    if (leftVal === null) {
-      return -1;
-    }
-    if (rightVal === null) {
-      return 1;
-    }
-    if (leftVal < rightVal) {
-      return -1;
-    } else if (leftVal > rightVal) {
-      return 1;
+    const comp = compareEntityFields(leftVal, rightVal);
+    if (comp !== 0) {
+      return comp;
     }
   }
 


### PR DESCRIPTION
Takes events from `replicache.experimentalWatch` and sends them to ZQL to maintain queries.

See `replicache-context.test.ts` for examples.

