### PR TITLE
zql [4/n] - pull historical data for initial query execution

### DIFF
--- a/src/zql/context/replicache-context.test.ts
+++ b/src/zql/context/replicache-context.test.ts
@@ -138,7 +138,7 @@ test('ZQL query with Replicache', async () => {
 
   const q = new EntityQueryImpl<{fields: E1}>(context, 'e1');
 
-  const view = q.select('id').where('str', '>', 'm').prepare().materialize();
+  const view = q.select('id').where('str', '>', 'm').prepare().view();
 
   await Promise.all([
     r.mutate.initE1({id: '1', str: 'c'}),

--- a/src/zql/integration.test.ts
+++ b/src/zql/integration.test.ts
@@ -1,0 +1,4 @@
+import {test} from 'vitest';
+
+test('build a query', () => {});
+test('run a query against a pre-populated collection', () => {});

--- a/src/zql/integration.test.ts
+++ b/src/zql/integration.test.ts
@@ -1,4 +1,0 @@
-import {test} from 'vitest';
-
-test('build a query', () => {});
-test('run a query against a pre-populated collection', () => {});

--- a/src/zql/ivm/graph/difference-stream-reader.test.ts
+++ b/src/zql/ivm/graph/difference-stream-reader.test.ts
@@ -112,9 +112,12 @@ test('drain', () => {
   r.enqueue([1, s1]);
   r.enqueue([2, s2]);
   r.enqueue([3, s3]);
-  expect(r.drain(2)).toEqual([s1, s2]);
+  expect(r.drain(2)).toEqual([
+    [1, s1],
+    [2, s2],
+  ]);
 
   // drain leaves the queue empty if we're draining all versions in it
-  expect(r.drain(3)).toEqual([s3]);
+  expect(r.drain(3)).toEqual([[3, s3]]);
   expect(r.isEmpty()).toBe(true);
 });

--- a/src/zql/ivm/graph/difference-stream-reader.test.ts
+++ b/src/zql/ivm/graph/difference-stream-reader.test.ts
@@ -33,6 +33,7 @@ test('run runs the operator', () => {
     notify() {},
     notifyCommitted() {},
     destroy() {},
+    messageUpstream() {},
   };
   const r = new DifferenceStreamReader(new DifferenceStreamWriter());
   r.setOperator(op);
@@ -50,6 +51,7 @@ test('notifyCommitted passes along to the operator', () => {
       ran = true;
     },
     destroy() {},
+    messageUpstream() {},
   };
   const r = new DifferenceStreamReader(new DifferenceStreamWriter());
   r.setOperator(op);
@@ -86,6 +88,7 @@ test('notifyCommitted does not notify on version mismatch', () => {
       ran = true;
     },
     destroy() {},
+    messageUpstream() {},
   };
   const r = new DifferenceStreamReader(new DifferenceStreamWriter());
   r.setOperator(op);

--- a/src/zql/ivm/graph/difference-stream-reader.ts
+++ b/src/zql/ivm/graph/difference-stream-reader.ts
@@ -4,6 +4,7 @@ import {Version} from '../types.js';
 import {DifferenceStreamWriter} from './difference-stream-writer.js';
 import {Operator} from './operators/operator.js';
 import {Queue} from './queue.js';
+import {Request} from './message.js';
 
 /**
  * Represents the input to an operator.
@@ -84,5 +85,9 @@ export class DifferenceStreamReader<T = unknown> {
   destroy() {
     this.#upstreamWriter.removeReaderAndMaybeDestroy(this);
     this.#queue.clear();
+  }
+
+  messageUpstream(message: Request) {
+    this.#upstreamWriter.messageUpstream(message, this);
   }
 }

--- a/src/zql/ivm/graph/difference-stream-reader.ts
+++ b/src/zql/ivm/graph/difference-stream-reader.ts
@@ -1,9 +1,8 @@
 import {invariant, must} from '../../error/asserts.js';
-import {Multiset} from '../multiset.js';
 import {Version} from '../types.js';
+import {Queue, QueueEntry} from './queue.js';
 import {DifferenceStreamWriter} from './difference-stream-writer.js';
 import {Operator} from './operators/operator.js';
-import {Queue} from './queue.js';
 import {Request} from './message.js';
 
 /**
@@ -36,7 +35,7 @@ export class DifferenceStreamReader<T = unknown> {
     this.#downstreamOperator = operator;
   }
 
-  enqueue(data: [Version, Multiset<T>]) {
+  enqueue(data: QueueEntry<T>) {
     this.#queue.enqueue(data);
   }
 
@@ -63,7 +62,7 @@ export class DifferenceStreamReader<T = unknown> {
   }
 
   drain(version: Version) {
-    const ret: Multiset<T>[] = [];
+    const ret: QueueEntry<T>[] = [];
     for (;;) {
       const data = this.#queue.peek();
       if (data === null) {
@@ -72,7 +71,7 @@ export class DifferenceStreamReader<T = unknown> {
       if (data[0] > version) {
         break;
       }
-      ret.push(data[1]);
+      ret.push(data);
       this.#queue.dequeue();
     }
     return ret;

--- a/src/zql/ivm/graph/difference-stream-writer.test.ts
+++ b/src/zql/ivm/graph/difference-stream-writer.test.ts
@@ -73,11 +73,11 @@ test('replying to a message only notifies along the requesting path', () => {
 
   expect(notifications).toEqual([false, false, false]);
 
-  w.queueData([1, new Multiset([]), createPullResponseMessage(msg.id)]);
+  w.queueData([1, new Multiset([]), createPullResponseMessage(msg)]);
   w.notify(1);
   expect(notifications).toEqual([false, true, false]);
 
   expect(() =>
-    w.queueData([2, new Multiset([]), createPullResponseMessage(msg.id)]),
+    w.queueData([2, new Multiset([]), createPullResponseMessage(msg)]),
   ).toThrow('No recipient');
 });

--- a/src/zql/ivm/graph/difference-stream-writer.test.ts
+++ b/src/zql/ivm/graph/difference-stream-writer.test.ts
@@ -14,6 +14,7 @@ test('notify readers', () => {
       notify() {},
       notifyCommitted() {},
       destroy() {},
+      messageUpstream() {},
     });
   });
 
@@ -35,6 +36,7 @@ test('notify committed readers', () => {
         notifications[i] = true;
       },
       destroy() {},
+      messageUpstream() {},
     });
   });
 

--- a/src/zql/ivm/graph/difference-stream-writer.test.ts
+++ b/src/zql/ivm/graph/difference-stream-writer.test.ts
@@ -1,5 +1,10 @@
 import {expect, test} from 'vitest';
 import {DifferenceStreamWriter} from './difference-stream-writer.js';
+import {Multiset} from '../multiset.js';
+import {DebugOperator} from './operators/debug-operator.js';
+import {createPullMessage, createPullResponseMessage} from './message.js';
+import {DifferenceStreamReader} from './difference-stream-reader.js';
+import {NoOp} from './operators/operator.js';
 
 test('notify readers', () => {
   const w = new DifferenceStreamWriter();
@@ -18,6 +23,7 @@ test('notify readers', () => {
     });
   });
 
+  w.queueData([1, new Multiset([])]);
   w.notify(1);
 
   expect(notifications).toEqual(readers.map(() => true));
@@ -40,8 +46,38 @@ test('notify committed readers', () => {
     });
   });
 
+  w.queueData([1, new Multiset([])]);
   w.notify(1);
   w.notifyCommitted(1);
 
   expect(notifications).toEqual(readers.map(() => true));
+});
+
+test('replying to a message only notifies along the requesting path', () => {
+  const w = new DifferenceStreamWriter<number>();
+  const readers = Array.from({length: 3}, () => w.newReader());
+  const notifications = readers.map(() => false);
+  const outputs: DifferenceStreamReader<number>[] = [];
+
+  readers.forEach((r, i) => {
+    const outputWriter = new DifferenceStreamWriter<number>();
+    const outputReader = outputWriter.newReader();
+    outputReader.setOperator(new NoOp());
+    outputs.push(outputReader);
+    new DebugOperator(r, outputWriter, () => (notifications[i] = true));
+  });
+
+  const msg = createPullMessage();
+
+  outputs[1].messageUpstream(msg);
+
+  expect(notifications).toEqual([false, false, false]);
+
+  w.queueData([1, new Multiset([]), createPullResponseMessage(msg.id)]);
+  w.notify(1);
+  expect(notifications).toEqual([false, true, false]);
+
+  expect(() =>
+    w.queueData([2, new Multiset([]), createPullResponseMessage(msg.id)]),
+  ).toThrow('No recipient');
 });

--- a/src/zql/ivm/graph/difference-stream.ts
+++ b/src/zql/ivm/graph/difference-stream.ts
@@ -1,6 +1,10 @@
 import {Multiset} from '../multiset.js';
+import {Source} from '../source/source.js';
 import {Version} from '../types.js';
-import {DifferenceStreamWriter} from './difference-stream-writer.js';
+import {
+  DifferenceStreamWriter,
+  RootDifferenceStreamWriter,
+} from './difference-stream-writer.js';
 import {IDifferenceStream} from './idifference-stream.js';
 import {LinearCountOperator} from './operators/count-operator.js';
 import {DebugOperator} from './operators/debug-operator.js';
@@ -16,7 +20,11 @@ import {QueueEntry} from './queue.js';
  * Encapsulates all the details of wiring together operators, readers, and writers.
  */
 export class DifferenceStream<T> implements IDifferenceStream<T> {
-  readonly #upstreamWriter = new DifferenceStreamWriter<T>();
+  readonly #upstreamWriter;
+
+  constructor(upstreamWriter?: DifferenceStreamWriter<T> | undefined) {
+    this.#upstreamWriter = upstreamWriter ?? new DifferenceStreamWriter<T>();
+  }
 
   map<O>(f: (value: T) => O): DifferenceStream<O> {
     const ret = new DifferenceStream<O>();
@@ -98,5 +106,15 @@ export class DifferenceStream<T> implements IDifferenceStream<T> {
 
   destroy() {
     this.#upstreamWriter.destroy();
+  }
+}
+
+export class RootDifferenceStream<T> extends DifferenceStream<T> {
+  constructor(source: Source<T>) {
+    super(new RootDifferenceStreamWriter<T>(source));
+  }
+
+  get stream() {
+    return this;
   }
 }

--- a/src/zql/ivm/graph/difference-stream.ts
+++ b/src/zql/ivm/graph/difference-stream.ts
@@ -7,6 +7,7 @@ import {DebugOperator} from './operators/debug-operator.js';
 import {DifferenceEffectOperator} from './operators/difference-effect-operator.js';
 import {FilterOperator} from './operators/filter-operator.js';
 import {MapOperator} from './operators/map-operator.js';
+import {QueueEntry} from './queue.js';
 
 /**
  * Used to build up a computation pipeline against a stream and then materialize it.
@@ -69,7 +70,7 @@ export class DifferenceStream<T> implements IDifferenceStream<T> {
     return ret;
   }
 
-  debug(onMessage: (c: Multiset<T>) => void) {
+  debug(onMessage: (c: QueueEntry<T>) => void) {
     const ret = new DifferenceStream<T>();
     new DebugOperator(
       this.#upstreamWriter.newReader(),

--- a/src/zql/ivm/graph/message.ts
+++ b/src/zql/ivm/graph/message.ts
@@ -1,0 +1,39 @@
+export type Request = {
+  id: number;
+  type: 'pull';
+};
+
+export type Reply = {
+  replyingTo: number;
+  type: 'pullResponse';
+};
+
+let messageID = 0;
+
+export function nextMessageID() {
+  return messageID++;
+}
+
+/**
+ * PullMessage is sent by leaves up to sources to tell them to send
+ * historical data.
+ *
+ * In the future, pull messages will gather up hoistable
+ * expressions and send them to the source to be evaluated.
+ *
+ * E.g., if there is a filter against the primary key. The source
+ * can use that information to restrict the rows it returns.
+ */
+export function createPullMessage(): Request {
+  return {
+    id: nextMessageID(),
+    type: 'pull',
+  };
+}
+
+export function createPullResponseMessage(requestId: number): Reply {
+  return {
+    replyingTo: requestId,
+    type: 'pullResponse',
+  };
+}

--- a/src/zql/ivm/graph/message.ts
+++ b/src/zql/ivm/graph/message.ts
@@ -1,4 +1,6 @@
-export type Request = {
+export type Request = PullMsg;
+
+type PullMsg = {
   id: number;
   type: 'pull';
 };
@@ -31,9 +33,9 @@ export function createPullMessage(): Request {
   };
 }
 
-export function createPullResponseMessage(requestId: number): Reply {
+export function createPullResponseMessage(pullMsg: PullMsg): Reply {
   return {
-    replyingTo: requestId,
+    replyingTo: pullMsg.id,
     type: 'pullResponse',
   };
 }

--- a/src/zql/ivm/graph/message.ts
+++ b/src/zql/ivm/graph/message.ts
@@ -1,11 +1,13 @@
 export type Request = PullMsg;
 
-type PullMsg = {
+export type PullMsg = {
   id: number;
   type: 'pull';
 };
 
-export type Reply = {
+export type Reply = PullReplyMsg;
+
+export type PullReplyMsg = {
   replyingTo: number;
   type: 'pullResponse';
 };

--- a/src/zql/ivm/graph/operators/count-operator.test.ts
+++ b/src/zql/ivm/graph/operators/count-operator.test.ts
@@ -28,5 +28,5 @@ test('summing a difference stream', () => {
 
   const final = outputReader.drain(1);
   expect(final.length).toBe(1);
-  expect([...final[0].entries]).toEqual([[1, 1]]);
+  expect([...final[0][1].entries]).toEqual([[1, 1]]);
 });

--- a/src/zql/ivm/graph/operators/debug-operator.ts
+++ b/src/zql/ivm/graph/operators/debug-operator.ts
@@ -1,7 +1,7 @@
-import {Multiset} from '../../multiset.js';
 import {Version} from '../../types.js';
 import {DifferenceStreamReader} from '../difference-stream-reader.js';
 import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {QueueEntry} from '../queue.js';
 import {UnaryOperator} from './unary-operator.js';
 
 /**
@@ -11,12 +11,12 @@ export class DebugOperator<T> extends UnaryOperator<T, T> {
   constructor(
     input: DifferenceStreamReader<T>,
     output: DifferenceStreamWriter<T>,
-    onMessage: (c: Multiset<T>) => void,
+    onMessage: (c: QueueEntry<T>) => void,
   ) {
     const inner = (version: Version) => {
-      for (const collection of this.inputMessages(version)) {
-        onMessage(collection);
-        this._output.queueData([version, collection]);
+      for (const entry of this.inputMessages(version)) {
+        onMessage(entry);
+        this._output.queueData(entry);
       }
     };
     super(input, output, inner);

--- a/src/zql/ivm/graph/operators/difference-effect-operator.ts
+++ b/src/zql/ivm/graph/operators/difference-effect-operator.ts
@@ -18,9 +18,9 @@ export class DifferenceEffectOperator<T> extends UnaryOperator<T, T> {
   ) {
     const inner = (version: Version) => {
       this.#collected = [];
-      for (const collection of this.inputMessages(version)) {
-        this.#collected.push(collection);
-        this._output.queueData([version, collection]);
+      for (const entry of this.inputMessages(version)) {
+        this.#collected.push(entry[1]);
+        this._output.queueData(entry);
       }
     };
     super(input, output, inner);

--- a/src/zql/ivm/graph/operators/filter-operator.test.ts
+++ b/src/zql/ivm/graph/operators/filter-operator.test.ts
@@ -28,7 +28,7 @@ test('does not emit any rows that fail the filter', () => {
   const items = outReader.drain(1);
 
   expect(items.length).toBe(1);
-  expect([...items[0].entries].length).toBe(0);
+  expect([...items[0][1].entries].length).toBe(0);
 });
 
 test('emits all rows that pass the filter (including deletes / retractions)', () => {
@@ -55,7 +55,7 @@ test('emits all rows that pass the filter (including deletes / retractions)', ()
   const items = outReader.drain(1);
 
   expect(items.length).toBe(1);
-  const entries = [...items[0].entries];
+  const entries = [...items[0][1].entries];
   expect(entries).toEqual([
     [1, 1],
     [2, 2],
@@ -95,6 +95,6 @@ test('test that filter is lazy / the filter is not actually run until we pull on
 
   const items = outReader.drain(1);
   // consume all the rows
-  [...items[0].entries];
+  [...items[0][1].entries];
   expect(called).toBe(true);
 });

--- a/src/zql/ivm/graph/operators/linear-unary-operator.ts
+++ b/src/zql/ivm/graph/operators/linear-unary-operator.ts
@@ -11,8 +11,12 @@ export class LinearUnaryOperator<I, O> extends UnaryOperator<I, O> {
     f: (input: Multiset<I>) => Multiset<O>,
   ) {
     const inner = (v: Version) => {
-      for (const collection of this.inputMessages(v)) {
-        this._output.queueData([v, f(collection)]);
+      for (const entry of this.inputMessages(v)) {
+        if (entry.length === 3) {
+          this._output.queueData([v, f(entry[1]), entry[2]]);
+        } else {
+          this._output.queueData([v, f(entry[1])]);
+        }
       }
     };
     super(input, output, inner);

--- a/src/zql/ivm/graph/operators/map-operator.test.ts
+++ b/src/zql/ivm/graph/operators/map-operator.test.ts
@@ -35,7 +35,7 @@ test('lazy', () => {
 
   const items = outReader.drain(1);
   // consume all the rows
-  [...items[0].entries];
+  [...items[0][1].entries];
   expect(called).toBe(true);
 });
 
@@ -63,7 +63,7 @@ test('applies to rows', () => {
   const items = outReader.drain(1);
 
   expect(items.length).toBe(1);
-  const entries = [...items[0].entries];
+  const entries = [...items[0][1].entries];
   expect(entries).toMatchObject([
     [2, 1],
     [4, 2],

--- a/src/zql/ivm/graph/operators/pass-through.ts
+++ b/src/zql/ivm/graph/operators/pass-through.ts
@@ -9,8 +9,8 @@ export class PassThroughOperator<I> extends UnaryOperator<I, I> {
     output: DifferenceStreamWriter<I>,
   ) {
     const inner = (v: Version) => {
-      for (const collection of this.inputMessages(v)) {
-        this._output.queueData([v, collection]);
+      for (const entry of this.inputMessages(v)) {
+        this._output.queueData(entry);
       }
     };
     super(input, output, inner);

--- a/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/src/zql/ivm/graph/operators/unary-operator.ts
@@ -1,8 +1,8 @@
-import {Multiset} from '../../multiset.js';
 import {Version} from '../../types.js';
 import {DifferenceStreamReader} from '../difference-stream-reader.js';
 import {DifferenceStreamWriter} from '../difference-stream-writer.js';
 import {OperatorBase} from './operator.js';
+import {QueueEntry} from '../queue.js';
 
 export class UnaryOperator<I, O> extends OperatorBase<O> {
   constructor(
@@ -14,6 +14,6 @@ export class UnaryOperator<I, O> extends OperatorBase<O> {
   }
 
   inputMessages(version: Version) {
-    return (this._inputs[0]?.drain(version) ?? []) as Multiset<I>[];
+    return (this._inputs[0]?.drain(version) ?? []) as QueueEntry<I>[];
   }
 }

--- a/src/zql/ivm/graph/queue.test.ts
+++ b/src/zql/ivm/graph/queue.test.ts
@@ -6,7 +6,6 @@ import {InvariantViolation} from '../../error/asserts.js';
 test('Rejects data from the past', () => {
   const q = new Queue();
   q.enqueue([1, new Multiset([])]);
-  expect(() => q.enqueue([1, new Multiset([])])).toThrow(InvariantViolation);
   expect(() => q.enqueue([0, new Multiset([])])).toThrow(InvariantViolation);
   expect(() => q.enqueue([-1, new Multiset([])])).toThrow(InvariantViolation);
 });

--- a/src/zql/ivm/graph/queue.ts
+++ b/src/zql/ivm/graph/queue.ts
@@ -1,9 +1,14 @@
 import {invariant, must} from '../../error/asserts.js';
 import {Multiset} from '../multiset.js';
 import {Version} from '../types.js';
+import {Reply} from './message.js';
+
+export type QueueEntry<T> =
+  | readonly [Version, Multiset<T>, Reply]
+  | readonly [Version, Multiset<T>];
 
 type Node<T> = {
-  data: readonly [Version, Multiset<T>];
+  data: QueueEntry<T>;
   next: Node<T> | null;
 };
 
@@ -18,7 +23,7 @@ export class Queue<T> {
   #head: Node<T> | null = null;
   #tail: Node<T> | null = null;
 
-  enqueue(data: readonly [Version, Multiset<T>]) {
+  enqueue(data: QueueEntry<T>) {
     invariant(
       data[0] > this.#lastSeenVersion,
       'Received stale data along a graph edge.',

--- a/src/zql/ivm/graph/queue.ts
+++ b/src/zql/ivm/graph/queue.ts
@@ -25,7 +25,7 @@ export class Queue<T> {
 
   enqueue(data: QueueEntry<T>) {
     invariant(
-      data[0] > this.#lastSeenVersion,
+      data[0] >= this.#lastSeenVersion,
       'Received stale data along a graph edge.',
     );
 

--- a/src/zql/ivm/materialite.ts
+++ b/src/zql/ivm/materialite.ts
@@ -7,6 +7,7 @@ import {must} from '../error/asserts.js';
 
 export type MaterialiteForSourceInternal = {
   readonly materialite: Materialite;
+  getVersion(): number;
   addDirtySource(source: SourceInternal): void;
 };
 
@@ -21,6 +22,7 @@ export class Materialite {
     this.#version = 0;
     this.#internal = {
       materialite: this,
+      getVersion: () => this.#version,
       addDirtySource: (source: SourceInternal) => {
         this.#dirtySources.add(source);
         // auto-commit if not in a transaction

--- a/src/zql/ivm/source/source.ts
+++ b/src/zql/ivm/source/source.ts
@@ -1,10 +1,13 @@
+import {DifferenceStreamReader} from '../graph/difference-stream-reader.js';
 import {DifferenceStream} from '../graph/difference-stream.js';
 import {Version} from '../types.js';
+import {Request} from '../graph/message.js';
 
 export interface Source<T> {
   readonly stream: DifferenceStream<T>;
   add(value: T): this;
   delete(value: T): this;
+  processMessage(message: Request, downstream: DifferenceStreamReader<T>): void;
 }
 
 export interface SourceInternal {

--- a/src/zql/ivm/source/source.ts
+++ b/src/zql/ivm/source/source.ts
@@ -8,6 +8,7 @@ export interface Source<T> {
   add(value: T): this;
   delete(value: T): this;
   processMessage(message: Request, downstream: DifferenceStreamReader<T>): void;
+  seed(values: Iterable<T>): this;
 }
 
 export interface SourceInternal {

--- a/src/zql/ivm/source/stateless-source.ts
+++ b/src/zql/ivm/source/stateless-source.ts
@@ -1,13 +1,16 @@
 import {MaterialiteForSourceInternal} from '../materialite.js';
 import {Entry, Multiset} from '../multiset.js';
 import {DifferenceStream} from '../graph/difference-stream.js';
-import {SourceInternal} from './source.js';
+import {Source, SourceInternal} from './source.js';
 import {Version} from '../types.js';
+import {createPullResponseMessage} from '../graph/message.js';
+import {Request} from '../graph/message.js';
+import {DifferenceStreamReader} from '../graph/difference-stream-reader.js';
 
 /**
  * Is a source of values.
  */
-export class StatelessSource<T> {
+export class StatelessSource<T> implements Source<T> {
   #stream: DifferenceStream<T>;
   readonly #internal: SourceInternal;
   readonly #materialite: MaterialiteForSourceInternal;
@@ -41,6 +44,33 @@ export class StatelessSource<T> {
 
   get stream(): DifferenceStream<T> {
     return this.#stream;
+  }
+
+  processMessage(
+    message: Request,
+    downstream: DifferenceStreamReader<T>,
+  ): void {
+    switch (message.type) {
+      case 'pull': {
+        // This is problematic under the current model of how we run the graph.
+        // As in, I don't think this'll work for operators with many inputs.
+        // So this presents another reason to move to optimistically running the graph
+        // as soon as data is enqueued and making the operators
+        // able to handle partial inputs. Something I thought avoiding would be simpler but turns out the opposite.
+        // The other reason is interactive transactions as discussed with Erik
+        // For interactive transactions we also can't wait until all inputs have been updated
+        // before running the graph.
+        const response = createPullResponseMessage(message);
+        downstream.enqueue([
+          this.#materialite.getVersion(),
+          new Multiset([]),
+          response,
+        ]);
+        downstream.notify(this.#materialite.getVersion());
+        downstream.notifyCommitted(this.#materialite.getVersion());
+        break;
+      }
+    }
   }
 
   addAll(values: Iterable<T>): this {

--- a/src/zql/ivm/source/stateless-source.ts
+++ b/src/zql/ivm/source/stateless-source.ts
@@ -46,6 +46,10 @@ export class StatelessSource<T> implements Source<T> {
     return this.#stream;
   }
 
+  seed(_: Iterable<T>): this {
+    return this;
+  }
+
   processMessage(
     message: Request,
     downstream: DifferenceStreamReader<T>,

--- a/src/zql/ivm/view/abstract-view.ts
+++ b/src/zql/ivm/view/abstract-view.ts
@@ -2,6 +2,8 @@ import {Materialite} from '../materialite.js';
 import {DifferenceStream} from '../graph/difference-stream.js';
 import {Version} from '../types.js';
 import {View} from './view.js';
+import {assert} from '../../error/asserts.js';
+import {createPullMessage} from '../graph/message.js';
 
 export abstract class AbstractView<T, CT> implements View<CT> {
   readonly #stream;
@@ -35,11 +37,21 @@ export abstract class AbstractView<T, CT> implements View<CT> {
         this._notifyCommitted(this.value, v);
       },
       destroy() {},
+      messageUpstream: _ => {
+        assert(
+          false,
+          'Message Upstream should not be called in a view operator',
+        );
+      },
     });
   }
 
   get stream() {
     return this.#stream;
+  }
+
+  pullHistoricalData() {
+    this._reader.messageUpstream(createPullMessage());
   }
 
   protected _notifyCommitted(d: CT, v: Version) {

--- a/src/zql/ivm/view/abstract-view.ts
+++ b/src/zql/ivm/view/abstract-view.ts
@@ -35,7 +35,6 @@ export abstract class AbstractView<T, CT> implements View<CT> {
       },
       notify(_v: Version) {},
       notifyCommitted: (v: Version) => {
-        console.log('set hydrated');
         this.#hydrated = true;
         this._notifyCommitted(this.value, v);
       },

--- a/src/zql/ivm/view/abstract-view.ts
+++ b/src/zql/ivm/view/abstract-view.ts
@@ -12,6 +12,7 @@ export abstract class AbstractView<T, CT> implements View<CT> {
   protected _notifiedListenersVersion = -1;
   readonly #listeners: Set<(s: CT, v: Version) => void> = new Set();
   readonly name;
+  #hydrated = false;
 
   abstract get value(): CT;
 
@@ -34,6 +35,8 @@ export abstract class AbstractView<T, CT> implements View<CT> {
       },
       notify(_v: Version) {},
       notifyCommitted: (v: Version) => {
+        console.log('set hydrated');
+        this.#hydrated = true;
         this._notifyCommitted(this.value, v);
       },
       destroy() {},
@@ -48,6 +51,10 @@ export abstract class AbstractView<T, CT> implements View<CT> {
 
   get stream() {
     return this.#stream;
+  }
+
+  get hydrated() {
+    return this.#hydrated;
   }
 
   pullHistoricalData() {

--- a/src/zql/ivm/view/primitive-view.ts
+++ b/src/zql/ivm/view/primitive-view.ts
@@ -29,7 +29,7 @@ export class ValueView<T> extends AbstractView<T, T | null> {
       return;
     }
 
-    const lastCollection = must(collections[collections.length - 1]);
+    const lastCollection = must(collections[collections.length - 1])[1];
     let lastValue = undefined;
     for (const [value, mult] of lastCollection.entries) {
       if (mult > 0) {

--- a/src/zql/ivm/view/tree-view.ts
+++ b/src/zql/ivm/view/tree-view.ts
@@ -64,8 +64,8 @@ class AbstractTreeView<T> extends AbstractView<T, T[]> {
     let changed = false;
 
     let newData = this.#data;
-    for (const c of collections) {
-      [changed, newData] = this.#sink(c, newData) || changed;
+    for (const entry of collections) {
+      [changed, newData] = this.#sink(entry[1], newData) || changed;
     }
     this.#data = newData;
 

--- a/src/zql/ivm/view/view.ts
+++ b/src/zql/ivm/view/view.ts
@@ -11,5 +11,6 @@ export interface View<T> {
     options?: {autoCleanup?: boolean},
   ): void;
   get value(): T;
+  get hydrated(): boolean;
   pullHistoricalData(): void;
 }

--- a/src/zql/ivm/view/view.ts
+++ b/src/zql/ivm/view/view.ts
@@ -11,4 +11,5 @@ export interface View<T> {
     options?: {autoCleanup?: boolean},
   ): void;
   get value(): T;
+  pullHistoricalData(): void;
 }

--- a/src/zql/query/entity-query.test.ts
+++ b/src/zql/query/entity-query.test.ts
@@ -22,14 +22,14 @@ test('query types', () => {
   expectTypeOf(q.select).toBeCallableWith('id');
   expectTypeOf(q.select).toBeCallableWith('str', 'optStr');
 
-  expectTypeOf(
-    q.select('id', 'str').prepare().materialize().value,
-  ).toMatchTypeOf<readonly {id: string; str: string}[]>();
-  expectTypeOf(q.select('id').prepare().materialize().value).toMatchTypeOf<
-    readonly {id: string}[]
+  expectTypeOf(q.select('id', 'str').prepare().exec()).toMatchTypeOf<
+    Promise<readonly {id: string; str: string}[]>
   >();
-  expectTypeOf(q.select('optStr').prepare().materialize().value).toMatchTypeOf<
-    readonly {optStr?: string}[]
+  expectTypeOf(q.select('id').prepare().exec()).toMatchTypeOf<
+    Promise<readonly {id: string}[]>
+  >();
+  expectTypeOf(q.select('optStr').prepare().exec()).toMatchTypeOf<
+    Promise<readonly {optStr?: string}[]>
   >();
 
   // where/order/limit do not change return type
@@ -40,8 +40,8 @@ test('query types', () => {
       .limit(1)
       .asc('id')
       .prepare()
-      .materialize().value,
-  ).toMatchTypeOf<readonly {id: string; str: string}[]>();
+      .exec(),
+  ).toMatchTypeOf<Promise<readonly {id: string; str: string}[]>>();
 
   expectTypeOf(q.where).toBeCallableWith('id', '=', 'foo');
   expectTypeOf(q.where).toBeCallableWith('str', '<', 'foo');
@@ -53,7 +53,7 @@ test('query types', () => {
   // @ts-expect-error - comparing with the wrong data type for the value is an error
   q.where('id', '=', 1);
 
-  expectTypeOf(q.count().prepare().materialize().value).toMatchTypeOf<number>();
+  expectTypeOf(q.count().prepare().exec()).toMatchTypeOf<Promise<number>>();
 });
 
 const e1 = z.object({

--- a/src/zql/query/entity-query.ts
+++ b/src/zql/query/entity-query.ts
@@ -2,7 +2,7 @@ import {AST, Operator, Primitive} from '../ast/ast.js';
 import {Context} from '../context/context.js';
 import {Misuse} from '../error/misuse.js';
 import {EntitySchema} from '../schema/entity-schema.js';
-import {Statement, StatementImpl} from './statement.js';
+import {Statement} from './statement.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SelectedFields<T, Fields extends Selectable<any>[]> = Pick<
@@ -162,7 +162,6 @@ export class EntityQueryImpl<S extends EntitySchema, Return = []>
   }
 
   prepare(): Statement<Return> {
-    // TODO: build the IVM pipeline
-    return new StatementImpl<S, Return>(this.#context, this);
+    return new Statement<Return>(this.#context, this);
   }
 }

--- a/src/zql/query/entity-query.ts
+++ b/src/zql/query/entity-query.ts
@@ -1,8 +1,8 @@
+import {Statement} from './statement.js';
 import {AST, Operator, Primitive} from '../ast/ast.js';
 import {Context} from '../context/context.js';
 import {Misuse} from '../error/misuse.js';
 import {EntitySchema} from '../schema/entity-schema.js';
-import {Statement} from './statement.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SelectedFields<T, Fields extends Selectable<any>[]> = Pick<

--- a/src/zql/query/statement.ts
+++ b/src/zql/query/statement.ts
@@ -78,7 +78,7 @@ export class Statement<TReturn> implements IStatement<TReturn> {
   }
 
   // Note: should we provide a version that takes a callback?
-  // So it can resolve in the same event loop tick?
+  // So it can resolve in the same micro task?
   // since, in the common case, the data will always be available.
   exec() {
     if (this.#materialization === null) {

--- a/src/zql/query/statement.ts
+++ b/src/zql/query/statement.ts
@@ -86,7 +86,6 @@ export class Statement<TReturn> implements IStatement<TReturn> {
     }
 
     if (this.#materialization?.hydrated) {
-      console.log('we be hydrated!');
       return Promise.resolve(this.#materialization.value) as Promise<
         MakeHumanReadable<TReturn>
       >;

--- a/src/zql/query/statement.ts
+++ b/src/zql/query/statement.ts
@@ -2,7 +2,7 @@ import {Entity} from '../../generate.js';
 import {buildPipeline, orderingProp} from '../ast-to-ivm/pipeline-builder.js';
 import {Primitive} from '../ast/ast.js';
 import {Context} from '../context/context.js';
-import {invariant} from '../error/asserts.js';
+import {invariant, must} from '../error/asserts.js';
 import {compareEntityFields} from '../ivm/compare.js';
 import {DifferenceStream} from '../ivm/graph/difference-stream.js';
 import {ValueView} from '../ivm/view/primitive-view.js';
@@ -11,14 +11,14 @@ import {View} from '../ivm/view/view.js';
 import {EntitySchema} from '../schema/entity-schema.js';
 import {EntityQuery, MakeHumanReadable} from './entity-query.js';
 
-export interface Statement<TReturn> {
-  materialize: () => View<MakeHumanReadable<TReturn>>;
-  destroy: () => void;
+export interface IStatement<TReturn> {
+  subscribe(cb: (value: MakeHumanReadable<TReturn>) => void): () => void;
+  exec(): Promise<MakeHumanReadable<TReturn>>;
+  view(): View<TReturn>;
+  destroy(): void;
 }
 
-export class StatementImpl<TSchema extends EntitySchema, TReturn>
-  implements Statement<TReturn>
-{
+export class Statement<TReturn> implements IStatement<TReturn> {
   readonly #pipeline;
   readonly #ast;
   readonly #context;
@@ -26,7 +26,7 @@ export class StatementImpl<TSchema extends EntitySchema, TReturn>
     TReturn extends [] ? TReturn[number] : TReturn
   > | null = null;
 
-  constructor(c: Context, q: EntityQuery<TSchema, TReturn>) {
+  constructor(c: Context, q: EntityQuery<EntitySchema, TReturn>) {
     this.#ast = q._ast;
     this.#pipeline = buildPipeline(
       <T extends Entity>(sourceName: string) =>
@@ -37,7 +37,7 @@ export class StatementImpl<TSchema extends EntitySchema, TReturn>
     this.#context = c;
   }
 
-  materialize(): View<MakeHumanReadable<TReturn>> {
+  view(): View<TReturn> {
     // TODO: invariants to throw if the statement is not completely bound before materialization.
     if (this.#materialization === null) {
       if (this.#ast.select === 'count') {
@@ -66,11 +66,42 @@ export class StatementImpl<TSchema extends EntitySchema, TReturn>
     // the response of historical data.
     this.#materialization.pullHistoricalData();
 
-    return this.#materialization as View<MakeHumanReadable<TReturn>>;
+    return this.#materialization as View<TReturn>;
+  }
+
+  subscribe(cb: (value: MakeHumanReadable<TReturn>) => void) {
+    if (this.#materialization === null) {
+      this.view();
+    }
+
+    return must(this.#materialization).on(cb);
+  }
+
+  // Note: should we provide a version that takes a callback?
+  // So it can resolve in the same event loop tick?
+  // since, in the common case, the data will always be available.
+  exec() {
+    if (this.#materialization === null) {
+      this.view();
+    }
+
+    if (this.#materialization?.hydrated) {
+      console.log('we be hydrated!');
+      return Promise.resolve(this.#materialization.value) as Promise<
+        MakeHumanReadable<TReturn>
+      >;
+    }
+
+    return new Promise<MakeHumanReadable<TReturn>>(resolve => {
+      const cleanup = must(this.#materialization).on(value => {
+        resolve(value as MakeHumanReadable<TReturn>);
+        cleanup();
+      });
+    }) as Promise<MakeHumanReadable<TReturn>>;
   }
 
   // For savvy users that want to subscribe directly to diffs.
-  onDifference() {}
+  // onDifference() {}
 
   destroy() {
     this.#pipeline.destroy();

--- a/src/zql/query/statement.ts
+++ b/src/zql/query/statement.ts
@@ -62,6 +62,10 @@ export class StatementImpl<TSchema extends EntitySchema, TReturn>
       }
     }
 
+    // TODO: we'll want some ability to let a caller await
+    // the response of historical data.
+    this.#materialization.pullHistoricalData();
+
     return this.#materialization as View<MakeHumanReadable<TReturn>>;
   }
 

--- a/src/zql/util/iterables.ts
+++ b/src/zql/util/iterables.ts
@@ -1,0 +1,9 @@
+export function* mapIter<T, U>(
+  iter: Iterable<T>,
+  f: (t: T, index: number) => U,
+): Iterable<U> {
+  let index = 0;
+  for (const t of iter) {
+    yield f(t, index++);
+  }
+}


### PR DESCRIPTION
The pipelines process write events as they happen but when a pipeline is first attached to a source, we need to query against all historical data.

This adds a path for leaves of the graph to send a message up to the roots. The roots can then reply back, only visiting the paths that sent a request.

![image](https://github.com/rocicorp/rails/assets/1009003/f3d62465-c731-4d1c-b0dd-5117dad6543b)

# To be added later --

When asking for historical data we don't want to send the _entire_ table back if possible.

- https://github.com/rocicorp/rails/pull/39
