### PR TITLE
chore: Make Replicache structural typed

### DIFF
--- a/src/replicache-like.ts
+++ b/src/replicache-like.ts
@@ -1,0 +1,45 @@
+import {ReadonlyJSONValue} from './json.js';
+
+type DiffOperationAdd<Key, Value = ReadonlyJSONValue> = {
+  readonly op: 'add';
+  readonly key: Key;
+  readonly newValue: Value;
+};
+type DiffOperationDel<Key, Value = ReadonlyJSONValue> = {
+  readonly op: 'del';
+  readonly key: Key;
+  readonly oldValue: Value;
+};
+type DiffOperationChange<Key, Value = ReadonlyJSONValue> = {
+  readonly op: 'change';
+  readonly key: Key;
+  readonly oldValue: Value;
+  readonly newValue: Value;
+};
+type DiffOperation<Key> =
+  | DiffOperationAdd<Key>
+  | DiffOperationDel<Key>
+  | DiffOperationChange<Key>;
+type NoIndexDiff = readonly DiffOperation<string>[];
+type WatchNoIndexCallback = (diff: NoIndexDiff) => void;
+type WatchIndexCallback = (diff: IndexDiff) => void;
+type IndexKey = readonly [secondary: string, primary: string];
+type IndexDiff = readonly DiffOperation<IndexKey>[];
+type WatchOptions = WatchIndexOptions | WatchNoIndexOptions;
+type WatchIndexOptions = WatchNoIndexOptions & {
+  indexName: string;
+};
+type WatchNoIndexOptions = {
+  prefix?: string | undefined;
+  initialValuesInFirstDiff?: boolean | undefined;
+};
+type WatchCallbackForOptions<Options extends WatchOptions> =
+  Options extends WatchIndexOptions ? WatchIndexCallback : WatchNoIndexCallback;
+
+export type ReplicacheLike = {
+  experimentalWatch(callback: WatchNoIndexCallback): () => void;
+  experimentalWatch<Options extends WatchOptions>(
+    callback: WatchCallbackForOptions<Options>,
+    options?: Options,
+  ): () => void;
+};

--- a/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -1,6 +1,6 @@
+import {AST, Condition, ConditionList, Operator} from '../ast/ast.js';
 import {assert, must} from '../error/asserts.js';
 import {DifferenceStream} from '../ivm/graph/difference-stream.js';
-import {AST, Condition, ConditionList, Operator} from '../ast/ast.js';
 
 export const orderingProp = Symbol();
 
@@ -85,8 +85,7 @@ function applyWhere(stream: DifferenceStream<unknown>, where: ConditionList) {
   //        |
   //
   // So `ORs` cause a fork (two branches that need to be evaluated) and then that fork is combined.
-  for (let i = 0; i < where.length; i++) {
-    const condition = where[i];
+  for (const condition of where) {
     if (condition === 'AND') {
       continue;
     }

--- a/src/zql/context/replicache-context.ts
+++ b/src/zql/context/replicache-context.ts
@@ -1,13 +1,14 @@
-import {ExperimentalNoIndexDiff, Replicache} from 'replicache';
-import {Materialite} from '../ivm/materialite.js';
+import {ExperimentalNoIndexDiff} from 'replicache';
 import {Entity} from '../../generate.js';
-import {Source} from '../ivm/source/source.js';
-import {MutableSetSource} from '../ivm/source/set-source.js';
+import {ReplicacheLike} from '../../replicache-like.js';
+import {Ordering} from '../ast/ast.js';
 import {assert, invariant} from '../error/asserts.js';
 import {compareEntityFields} from '../ivm/compare.js';
-import {Ordering} from '../ast/ast.js';
+import {Materialite} from '../ivm/materialite.js';
+import {MutableSetSource} from '../ivm/source/set-source.js';
+import {Source} from '../ivm/source/source.js';
 
-export function makeReplicacheContext(rep: Replicache) {
+export function makeReplicacheContext(rep: ReplicacheLike) {
   const materialite = new Materialite();
   const sourceStore = new ReplicacheSourceStore(rep, materialite);
 
@@ -38,11 +39,11 @@ export function makeReplicacheContext(rep: Replicache) {
  * And shares the work between queries.
  */
 class ReplicacheSourceStore {
-  readonly #rep: Replicache;
+  readonly #rep: ReplicacheLike;
   readonly #materialite: Materialite;
   readonly #sources = new Map<string, ReplicacheSource>();
 
-  constructor(rep: Replicache, materialite: Materialite) {
+  constructor(rep: ReplicacheLike, materialite: Materialite) {
     this.#rep = rep;
     this.#materialite = materialite;
   }
@@ -63,7 +64,7 @@ class ReplicacheSource {
   readonly #sources: Map<string, Source<Entity>> = new Map();
   readonly #canonicalSource: MutableSetSource<Entity>;
 
-  constructor(rep: Replicache, materialite: Materialite, name: string) {
+  constructor(rep: ReplicacheLike, materialite: Materialite, name: string) {
     this.#canonicalSource =
       materialite.newSetSource<Entity>(canonicalComparator);
     this.#materialite = materialite;


### PR DESCRIPTION
Instead of taking a Replicache instance ZQL now takes something that has an experimentalWatch method.