### PR TITLE
feat: Add support for OR in the pipeline

### DIFF
--- a/src/zql/ivm/graph/difference-stream-writer.ts
+++ b/src/zql/ivm/graph/difference-stream-writer.ts
@@ -93,9 +93,9 @@ export class DifferenceStreamWriter<T> {
    * Notifies any observers that a transaction
    * has completed. Called immediately after transaction commit.
    */
-  notifyCommitted(v: Version) {
+  notifyCommitted(version: Version) {
     for (const r of this.#toNotify) {
-      r.notifyCommitted(v);
+      r.notifyCommitted(version);
     }
   }
 
@@ -141,7 +141,7 @@ export class DifferenceStreamWriter<T> {
 
   destroy() {
     this._downstreamReaders.length = 0;
-    // The root differnce stream will not have an upstream operator
+    // The root difference stream will not have an upstream operator
     this.#upstreamOperator?.destroy();
   }
 }

--- a/src/zql/ivm/graph/operators/branch-operator.test.ts
+++ b/src/zql/ivm/graph/operators/branch-operator.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {BranchOperator} from './branch-operator.js';
+import {NoOp} from './operator.js';
+
+test('All branches gets notified', () => {
+  const inputWriter = new DifferenceStreamWriter<number>();
+  const inputReader = inputWriter.newReader();
+  const outputs = [
+    new DifferenceStreamWriter<number>(),
+    new DifferenceStreamWriter<number>(),
+    new DifferenceStreamWriter<number>(),
+  ];
+
+  new BranchOperator(inputReader, outputs);
+
+  const outReaders = outputs.map(o => o.newReader());
+  outReaders.forEach(o => o.setOperator(new NoOp()));
+
+  const version = 1;
+
+  inputWriter.queueData([
+    version,
+    new Multiset([
+      [1, 1],
+      [2, 2],
+      [1, -1],
+      [2, -2],
+    ]),
+  ]);
+  inputWriter.notify(version);
+  inputWriter.notifyCommitted(version);
+
+  for (const outReader of outReaders) {
+    const items = outReader.drain(version);
+
+    expect(items.length).toBe(1);
+    const entries = [...items[0][1].entries];
+    expect(entries).toEqual([
+      [1, 1],
+      [2, 2],
+      [1, -1],
+      [2, -2],
+    ]);
+  }
+});

--- a/src/zql/ivm/graph/operators/branch-operator.ts
+++ b/src/zql/ivm/graph/operators/branch-operator.ts
@@ -1,0 +1,73 @@
+import {invariant} from '../../../error/asserts.js';
+import {Multiset} from '../../multiset.js';
+import {Version} from '../../types.js';
+import {DifferenceStreamReader} from '../difference-stream-reader.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {Request} from '../message.js';
+import {QueueEntry} from '../queue.js';
+import {Operator} from './operator.js';
+
+/**
+ * A dataflow operator (node) that has a single incoming edge (read handle) and
+ * many outgoing edges (write handles). It just puts all the input messages from
+ * the incoming stream into all the outgoing streams.
+ */
+export class BranchOperator<T> implements Operator {
+  #lastRunVersion: Version = -1;
+  #lastNotifyVersion: Version = -1;
+  protected readonly _input: DifferenceStreamReader<T>;
+  protected readonly _outputs: DifferenceStreamWriter<T>[];
+
+  constructor(
+    input: DifferenceStreamReader<T>,
+    outputs: DifferenceStreamWriter<T>[],
+  ) {
+    this._input = input;
+    this._outputs = outputs;
+    this._input.setOperator(this);
+    for (const output of this._outputs) {
+      output.setOperator(this);
+    }
+  }
+
+  run(version: Version) {
+    this.#lastRunVersion = version;
+
+    for (const entry of this._input.drain(version)) {
+      const data: QueueEntry<T> =
+        entry.length === 3
+          ? [version, entry[1] as Multiset<T>, entry[2]]
+          : [version, entry[1] as Multiset<T>];
+
+      for (const output of this._outputs) {
+        output.queueData(data);
+      }
+    }
+  }
+
+  notify(version: Version) {
+    invariant(version === this.#lastRunVersion, 'notify called out of order');
+    if (version === this.#lastNotifyVersion) {
+      // Don't double-notify an operator.
+      // It will have run and pulled values on the first notification at this version.
+      return;
+    }
+    for (const output of this._outputs) {
+      output.notify(version);
+    }
+  }
+
+  notifyCommitted(version: Version) {
+    for (const output of this._outputs) {
+      output.notifyCommitted(version);
+    }
+  }
+
+  destroy() {
+    this._input.destroy();
+  }
+
+  messageUpstream(message: Request): void {
+    this._input.messageUpstream(message);
+  }
+}

--- a/src/zql/ivm/graph/operators/concat-operator.test.ts
+++ b/src/zql/ivm/graph/operators/concat-operator.test.ts
@@ -1,0 +1,44 @@
+import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {ConcatOperator} from './concat-operator.js';
+import {NoOp} from './operator.js';
+
+test('All branches gets notified', () => {
+  const inputWriters = [
+    new DifferenceStreamWriter<number>(),
+    new DifferenceStreamWriter<number>(),
+    new DifferenceStreamWriter<number>(),
+  ];
+  const inputReaders = inputWriters.map(i => i.newReader());
+  const output = new DifferenceStreamWriter<number>();
+
+  new ConcatOperator(inputReaders, output);
+
+  const outReader = output.newReader();
+  outReader.setOperator(new NoOp());
+
+  const version = 1;
+
+  inputWriters[0].queueData([
+    version,
+    new Multiset([
+      [1, 1],
+      [2, 2],
+      [1, -1],
+      [2, -2],
+    ]),
+  ]);
+  inputWriters[0].notify(version);
+  inputWriters[0].notifyCommitted(version);
+
+  const items = outReader.drain(version);
+  expect(items.length).toBe(1);
+  const entries = [...items[0][1].entries];
+  expect(entries).toEqual([
+    [1, 1],
+    [2, 2],
+    [1, -1],
+    [2, -2],
+  ]);
+});

--- a/src/zql/ivm/graph/operators/concat-operator.ts
+++ b/src/zql/ivm/graph/operators/concat-operator.ts
@@ -1,0 +1,30 @@
+import {Version} from '../../types.js';
+import {DifferenceStreamReader} from '../difference-stream-reader.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {QueueEntry} from '../queue.js';
+import {OperatorBase} from './operator.js';
+
+/**
+ * A dataflow operator (node) that has many incoming edges (read handles) and
+ * one outgoing edge (write handle). It just puts all the input messages from
+ * all the incoming streams into the output stream.
+ */
+export class ConcatOperator<T> extends OperatorBase<T> {
+  constructor(
+    inputs: DifferenceStreamReader<T>[],
+    output: DifferenceStreamWriter<T>,
+  ) {
+    const inner = (version: Version) => {
+      for (const input of this._inputs) {
+        for (const entry of input.drain(version)) {
+          this._output.queueData(
+            entry.length === 3
+              ? ([version, entry[1], entry[2]] as QueueEntry<T>)
+              : ([version, entry[1]] as QueueEntry<T>),
+          );
+        }
+      }
+    };
+    super(inputs, output, inner);
+  }
+}

--- a/src/zql/ivm/graph/operators/difference-effect-operator.test.ts
+++ b/src/zql/ivm/graph/operators/difference-effect-operator.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
 import {DifferenceStreamWriter} from '../difference-stream-writer.js';
 import {DifferenceEffectOperator} from './difference-effect-operator.js';
-import {Multiset} from '../../multiset.js';
 
 test('calls effect with raw difference events', () => {
   const inputWriter = new DifferenceStreamWriter<number>();
@@ -10,11 +10,11 @@ test('calls effect with raw difference events', () => {
 
   let called = false;
   let value = 0;
-  let mult = 0;
+  let multiplicity = 0;
   new DifferenceEffectOperator(inputReader, output, (v, m) => {
     called = true;
     value = v;
-    mult = m;
+    multiplicity = m;
   });
 
   inputWriter.queueData([1, new Multiset([[1, 1]])]);
@@ -26,11 +26,11 @@ test('calls effect with raw difference events', () => {
   inputWriter.notifyCommitted(1);
   expect(called).toBe(true);
   expect(value).toBe(1);
-  expect(mult).toBe(1);
+  expect(multiplicity).toBe(1);
 
   called = false;
   value = 0;
-  mult = 0;
+  multiplicity = 0;
   inputWriter.queueData([2, new Multiset([[1, -1]])]);
   inputWriter.notify(2);
 
@@ -40,5 +40,5 @@ test('calls effect with raw difference events', () => {
   inputWriter.notifyCommitted(2);
   expect(called).toBe(true);
   expect(value).toBe(1);
-  expect(mult).toBe(-1);
+  expect(multiplicity).toBe(-1);
 });

--- a/src/zql/ivm/graph/operators/distinct-operator.test.ts
+++ b/src/zql/ivm/graph/operators/distinct-operator.test.ts
@@ -1,0 +1,59 @@
+import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {DistinctOperator} from './distinct-operator.js';
+import {NoOp} from './operator.js';
+
+test('calls effect with raw difference events', () => {
+  const inputWriter = new DifferenceStreamWriter<string>();
+  const inputReader = inputWriter.newReader();
+  const output = new DifferenceStreamWriter<string>();
+  const outputReader = output.newReader();
+  outputReader.setOperator(new NoOp());
+  new DistinctOperator(inputReader, output);
+
+  let version = 1;
+  inputWriter.queueData([
+    version,
+    new Multiset([
+      ['a', 1],
+      ['b', 2],
+      ['a', -1],
+      ['c', 1],
+    ]),
+  ]);
+  inputWriter.notify(version);
+  inputWriter.notifyCommitted(version);
+  expect(outputReader.drain(version)).toEqual([
+    [
+      version,
+      new Multiset([
+        ['b', 1],
+        ['c', 1],
+      ]),
+    ],
+  ]);
+
+  version++;
+  inputWriter.queueData([
+    version,
+    new Multiset([
+      ['a', -1],
+      ['b', 2],
+      ['a', 1],
+      ['c', -1],
+    ]),
+  ]);
+  inputWriter.queueData([version, new Multiset([['a', 1]])]);
+  inputWriter.queueData([version, new Multiset([['b', -2]])]);
+  inputWriter.notify(version);
+  inputWriter.notifyCommitted(version);
+
+  const items = outputReader.drain(version);
+  expect(items.length).toBe(1);
+  const entries = [...items[0][1].entries];
+  expect(entries).toEqual([
+    ['a', 1],
+    ['c', -1],
+  ]);
+});

--- a/src/zql/ivm/graph/operators/distinct-operator.ts
+++ b/src/zql/ivm/graph/operators/distinct-operator.ts
@@ -1,0 +1,51 @@
+import {filterIter, mapIter} from '../../../util/iterables.js';
+import {Multiset} from '../../multiset.js';
+import {Version} from '../../types.js';
+import {DifferenceStreamReader} from '../difference-stream-reader.js';
+import {DifferenceStreamWriter} from '../difference-stream-writer.js';
+import {UnaryOperator} from './unary-operator.js';
+
+export class DistinctOperator<T> extends UnaryOperator<T, T> {
+  constructor(
+    input: DifferenceStreamReader<T>,
+    output: DifferenceStreamWriter<T>,
+  ) {
+    super(input, output, version => this.#run(version));
+  }
+
+  #run(version: Version) {
+    type State<T> = [T, number][];
+
+    function addValue(state: State<T>, value: T, count: number) {
+      // TODO(arv): Use json equality
+      // TODO(arv): Use custom map impl where the key is json value?
+      const existing = state.find(e => e[0] === value);
+      if (!existing) {
+        state.push([value, count]);
+        return;
+      }
+      // Mutate in place
+      existing[1] += count;
+    }
+
+    const state: State<T> = [];
+    for (const queueEntry of this.inputMessages(version)) {
+      // TODO(arv): What about the Reply?
+      const multiset = queueEntry[1];
+      for (const entry of multiset.entries) {
+        addValue(state, entry[0], entry[1]);
+      }
+    }
+
+    // Create a new Multiset with the distinct values.
+    const distinctMultiset = new Multiset(
+      mapIter(
+        filterIter(state, e => e[1] !== 0),
+        ([data, multiplicity]) => [data, Math.sign(multiplicity)],
+      ),
+    );
+
+    // TODO(arv): What about the Reply?
+    this._output.queueData([version, distinctMultiset]);
+  }
+}

--- a/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/src/zql/ivm/graph/operators/unary-operator.ts
@@ -1,8 +1,8 @@
 import {Version} from '../../types.js';
 import {DifferenceStreamReader} from '../difference-stream-reader.js';
 import {DifferenceStreamWriter} from '../difference-stream-writer.js';
-import {OperatorBase} from './operator.js';
 import {QueueEntry} from '../queue.js';
+import {OperatorBase} from './operator.js';
 
 export class UnaryOperator<I, O> extends OperatorBase<O> {
   constructor(
@@ -13,7 +13,7 @@ export class UnaryOperator<I, O> extends OperatorBase<O> {
     super([input], output, fn);
   }
 
-  inputMessages(version: Version) {
+  inputMessages(version: Version): QueueEntry<I>[] {
     return (this._inputs[0]?.drain(version) ?? []) as QueueEntry<I>[];
   }
 }

--- a/src/zql/ivm/multiset.ts
+++ b/src/zql/ivm/multiset.ts
@@ -1,4 +1,4 @@
-export type Entry<T> = readonly [T, Multiplicity];
+export type Entry<T> = readonly [value: T, multiplicity: Multiplicity];
 export type Multiplicity = number;
 
 /**

--- a/src/zql/util/iterables.test.ts
+++ b/src/zql/util/iterables.test.ts
@@ -1,0 +1,24 @@
+import {expect, expectTypeOf, test} from 'vitest';
+import {filterIter} from './iterables.js';
+
+test('filter', () => {
+  const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  expect([...filterIter(arr, x => x % 2 === 0)]).toEqual([0, 2, 4, 6, 8]);
+});
+
+test('filter with is function', () => {
+  const arr2 = [0, 'a', 1, true, null, 2];
+  function asNumber(v: unknown): v is number {
+    return typeof v === 'number';
+  }
+  const filtered = [...filterIter(arr2, asNumber)];
+  expect(filtered).toEqual([0, 1, 2]);
+  expectTypeOf(filtered).toEqualTypeOf<number[]>();
+});
+
+test('filter with index', () => {
+  // Keep even indexes
+  const arr3 = ['a', 'b', 'c', 'd', 'e', 'f'];
+  const filtered2 = [...filterIter(arr3, (_, i) => i % 2 === 0)];
+  expect(filtered2).toEqual(['a', 'c', 'e']);
+});

--- a/src/zql/util/iterables.ts
+++ b/src/zql/util/iterables.ts
@@ -7,3 +7,23 @@ export function* mapIter<T, U>(
     yield f(t, index++);
   }
 }
+
+export function filterIter<V, O extends V>(
+  iter: Iterable<V>,
+  p: (value: V, index: number) => value is O,
+): Iterable<O>;
+export function filterIter<V>(
+  iter: Iterable<V>,
+  p: (value: V, index: number) => boolean,
+): Iterable<V>;
+export function* filterIter<V>(
+  iter: Iterable<V>,
+  p: (value: V, index: number) => boolean,
+): Iterable<V> {
+  let index = 0;
+  for (const value of iter) {
+    if (p(value, index++)) {
+      yield value;
+    }
+  }
+}


### PR DESCRIPTION
This does not yet build the AST.

It adds three new operator

## BranchOperator

The branch operator fans out.

```
     A
   / | \
  B  C  D
```

All messages received at A are forwarded to `B`, `C` and `D`.

## ConcatOperator

Is the reverse of the `BranchOperator`. It has multiple inputs and a single output.

```
  B  C  D
   \ | /
     A
```

All messages received are forwarded to A

## DistinctOperator

This operator "removes" "identical" messages received in the same "transaction"

 - removes: It sums up the multiplicity. Then it collapses the multiplicity to either 1 or -1.
 - identical: Right now it compares the value by `===`. This will not work  since we need to do JSON equality to deal with different objects representing the same logical value.
 - transaction: The call to `run`

@tantaman There are some TODOs in the code that I would like some clarity in.