### PR TITLE
feat(zql): Implement OR

### DIFF
--- a/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -8,7 +8,7 @@ import {
   SimpleOperator,
 } from '../ast/ast.js';
 import {must} from '../error/asserts.js';
-import {DifferenceStream} from '../ivm/graph/difference-stream.js';
+import {DifferenceStream, concat} from '../ivm/graph/difference-stream.js';
 
 export const orderingProp = Symbol();
 
@@ -152,8 +152,8 @@ function applyOr<T extends Entity>(
   // Or is done by branching the stream and then applying the conditions to each
   // branch. Then we merge the branches back together. At this point we need to
   // ensure we do not get duplicate entries so we add a distinct operator
-  const [first, ...rest] = conditions.map(c => applyWhere(stream, c));
-  return first.concat(...rest).distinct();
+  const branches = conditions.map(c => applyWhere(stream, c));
+  return concat(branches).distinct();
 }
 
 function applySimpleCondition<T extends Entity>(

--- a/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -103,8 +103,10 @@ function addOrdering(
   });
 }
 
-function applyWhere(stream: DifferenceStream<Entity>, where: Condition) {
-  let ret = stream;
+function applyWhere<T extends Entity>(
+  stream: DifferenceStream<T>,
+  where: Condition,
+) {
   // We'll handle `OR` and parentheticals like so:
   // OR: We'll create a new stream for the LHS and RHS of the OR then merge together.
   // Parentheticals: We'll create a new stream for the LHS and RHS of the operator involved in combining the parenthetical then merge together.
@@ -123,25 +125,47 @@ function applyWhere(stream: DifferenceStream<Entity>, where: Condition) {
   //
   // So `ORs` cause a fork (two branches that need to be evaluated) and then that fork is combined.
 
-  if (where.op === 'AND') {
-    for (const condition of where.conditions) {
-      ret = applyWhere(ret, condition);
-    }
-  } else {
-    ret = applySimpleCondition(ret, where);
+  switch (where.op) {
+    case 'AND':
+      return applyAnd(stream, where.conditions);
+    case 'OR':
+      return applyOr(stream, where.conditions);
+    default:
+      return applySimpleCondition(stream, where);
   }
-
-  return ret;
 }
 
-function applySimpleCondition(
-  stream: DifferenceStream<Entity>,
+function applyAnd<T extends Entity>(
+  stream: DifferenceStream<T>,
+  conditions: Condition[],
+) {
+  for (const condition of conditions) {
+    stream = applyWhere(stream, condition);
+  }
+  return stream;
+}
+
+function applyOr<T extends Entity>(
+  stream: DifferenceStream<T>,
+  conditions: Condition[],
+): DifferenceStream<T> {
+  // Or is done by branching the stream and then applying the conditions to each
+  // branch. Then we merge the branches back together. At this point we need to
+  // ensure we do not get duplicate entries so we add a distinct operator
+  const [first, ...rest] = conditions.map(c => applyWhere(stream, c));
+  return first.concat(...rest).distinct();
+}
+
+function applySimpleCondition<T extends Entity>(
+  stream: DifferenceStream<T>,
   condition: SimpleCondition,
 ) {
   const operator = getOperator(condition.op);
   return stream.filter(x =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    operator((x as any)[condition.field], condition.value.value),
+    operator(
+      (x as Record<string, unknown>)[condition.field],
+      condition.value.value,
+    ),
   );
 }
 
@@ -264,7 +288,7 @@ function makeKeyFunction(columns: string[]) {
     for (const column of columns) {
       ret.push(x[column]);
     }
-    // Would it be better to come up with someh hash function
+    // Would it be better to come up with some hash function
     // which can handle complex types?
     return JSON.stringify(ret);
   };

--- a/src/zql/ast/ast.ts
+++ b/src/zql/ast/ast.ts
@@ -47,7 +47,7 @@ export type AST = {
 
 export type Condition = SimpleCondition | Conjunction;
 export type Conjunction = {
-  op: 'AND'; // future OR
+  op: 'AND' | 'OR';
   conditions: Condition[];
 };
 export type SimpleOperator =

--- a/src/zql/integration.test.ts
+++ b/src/zql/integration.test.ts
@@ -1,12 +1,12 @@
+import fc from 'fast-check';
+import {nanoid} from 'nanoid';
+import {Replicache, TEST_LICENSE_KEY} from 'replicache';
 import {expect, test} from 'vitest';
 import {z} from 'zod';
 import {generate} from '../generate.js';
 import {makeReplicacheContext} from './context/replicache-context.js';
-import {Replicache, TEST_LICENSE_KEY} from 'replicache';
-import {nanoid} from 'nanoid';
-import fc from 'fast-check';
-import {EntityQuery} from './query/entity-query.js';
 import * as agg from './query/agg.js';
+import {EntityQuery, expression, or} from './query/entity-query.js';
 
 export async function tickAFewTimes(n = 10, time = 0) {
   for (let i = 0; i < n; i++) {
@@ -570,3 +570,55 @@ test('write delay with 1, 10, 100, 1000s of active queries', () => {});
 test('asc/desc difference does not create new sources', () => {});
 
 test('we do not do a full scan when the source order matches the view order', () => {});
+
+test('or where', async () => {
+  const {q, r} = setup();
+  const issues: Issue[] = [
+    {
+      id: 'a',
+      title: 'foo',
+      status: 'open',
+      priority: 'high',
+      assignee: 'charles',
+      created: Date.now(),
+      updated: Date.now(),
+    },
+    {
+      id: 'b',
+      title: 'bar',
+      status: 'open',
+      priority: 'medium',
+      assignee: 'bob',
+      created: Date.now(),
+      updated: Date.now(),
+    },
+    {
+      id: 'c',
+      title: 'baz',
+      status: 'closed',
+      priority: 'low',
+      assignee: 'alice',
+      created: Date.now(),
+      updated: Date.now(),
+    },
+  ] as const;
+  await Promise.all(issues.map(r.mutate.initIssue));
+
+  const stmt = q
+    .select('id')
+    .where(
+      or(
+        expression('status', '=', 'open'),
+        expression('priority', '>=', 'medium'),
+      ),
+    )
+    .prepare();
+  const rows = await stmt.exec();
+  expect(rows).toEqual([{id: 'a'}, {id: 'b'}]);
+
+  await r.mutate.deleteIssue('a');
+  const rows2 = await stmt.exec();
+  expect(rows2).toEqual([{id: 'b'}]);
+
+  await r.close();
+});

--- a/src/zql/ivm/graph/difference-stream.ts
+++ b/src/zql/ivm/graph/difference-stream.ts
@@ -127,11 +127,6 @@ export class DifferenceStream<T extends object> {
     );
   }
 
-  concat(...others: DifferenceStream<T>[]): DifferenceStream<T> {
-    const stream = new DifferenceStream<T>();
-    return stream.setUpstream(new ConcatOperator([this, ...others], stream));
-  }
-
   distinct(): DifferenceStream<T> {
     const stream = new DifferenceStream<T>();
     return stream.setUpstream(
@@ -208,4 +203,11 @@ export class DifferenceStream<T extends object> {
       this.destroy();
     }
   }
+}
+
+export function concat<T extends object>(
+  streams: DifferenceStream<T>[],
+): DifferenceStream<T> {
+  const stream = new DifferenceStream<T>();
+  return stream.setUpstream(new ConcatOperator(streams, stream));
 }

--- a/src/zql/ivm/graph/operators/concat-operator.test.ts
+++ b/src/zql/ivm/graph/operators/concat-operator.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from 'vitest';
 import {Multiset} from '../../multiset.js';
-import {DifferenceStream} from '../difference-stream.js';
+import {DifferenceStream, concat} from '../difference-stream.js';
 
 test('All branches notify', () => {
   type T = {x: number};
@@ -9,7 +9,7 @@ test('All branches notify', () => {
     new DifferenceStream<T>(),
     new DifferenceStream<T>(),
   ];
-  const output = inputs[0].concat(...inputs.slice(1));
+  const output = concat(inputs);
 
   let version = 1;
 
@@ -48,7 +48,7 @@ test('Test with single input', () => {
   type T = {x: number};
   const input = new DifferenceStream<T>();
 
-  const output = input.concat();
+  const output = concat([input]);
 
   const version = 1;
 

--- a/src/zql/ivm/graph/operators/concat-operator.test.ts
+++ b/src/zql/ivm/graph/operators/concat-operator.test.ts
@@ -1,0 +1,73 @@
+import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
+import {DifferenceStream} from '../difference-stream.js';
+
+test('All branches notify', () => {
+  type T = {x: number};
+  const inputs = [
+    new DifferenceStream<T>(),
+    new DifferenceStream<T>(),
+    new DifferenceStream<T>(),
+  ];
+  const output = inputs[0].concat(...inputs.slice(1));
+
+  let version = 1;
+
+  const items: Multiset<T>[] = [];
+  output.debug((v, d) => {
+    expect(v).toBe(version);
+    items.push(d);
+  });
+
+  inputs[0].newData(version, [
+    [{x: 1}, 1],
+    [{x: 2}, 2],
+  ]);
+  inputs[0].commit(version);
+
+  expect(items).toEqual([
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 2],
+    ],
+  ]);
+
+  items.length = 0;
+  version++;
+
+  inputs[0].newData(version, [[{x: 0}, 1]]);
+  inputs[1].newData(version, [[{x: 1}, 1]]);
+  inputs[2].newData(version, [[{x: 2}, 2]]);
+  inputs[0].commit(version);
+  inputs[1].commit(version);
+  inputs[2].commit(version);
+  expect(items).toEqual([[[{x: 0}, 1]], [[{x: 1}, 1]], [[{x: 2}, 2]]]);
+});
+
+test('Test with single input', () => {
+  type T = {x: number};
+  const input = new DifferenceStream<T>();
+
+  const output = input.concat();
+
+  const version = 1;
+
+  const items: Multiset<T>[] = [];
+  output.debug((v, d) => {
+    expect(v).toBe(version);
+    items.push(d);
+  });
+
+  input.newData(version, [
+    [{x: 1}, 1],
+    [{x: 2}, 2],
+  ]);
+  input.commit(version);
+
+  expect(items).toEqual([
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 2],
+    ],
+  ]);
+});

--- a/src/zql/ivm/graph/operators/concat-operator.ts
+++ b/src/zql/ivm/graph/operators/concat-operator.ts
@@ -1,0 +1,46 @@
+import {DifferenceStream, Listener} from '../difference-stream.js';
+import {PullMsg} from '../message.js';
+import {Operator} from './operator.js';
+
+/**
+ * A dataflow operator (node) that has many incoming edges and
+ * one outgoing edge (write handle). It just sends all the input messages from
+ * all the incoming operator to the output operators.
+ */
+export class ConcatOperator<T extends object> implements Operator {
+  readonly #listener: Listener<T>;
+  readonly #inputs: DifferenceStream<T>[];
+  readonly #output: DifferenceStream<T>;
+
+  constructor(inputs: DifferenceStream<T>[], output: DifferenceStream<T>) {
+    this.#inputs = inputs;
+    this.#output = output;
+    this.#listener = {
+      newDifference: (version, data) => {
+        output.newData(version, data);
+      },
+      commit: version => {
+        this.commit(version);
+      },
+    };
+    for (const input of inputs) {
+      input.addDownstream(this.#listener);
+    }
+  }
+
+  commit(version: number): void {
+    this.#output.commit(version);
+  }
+
+  messageUpstream(message: PullMsg): void {
+    for (const input of this.#inputs) {
+      input.messageUpstream(message, this.#listener);
+    }
+  }
+
+  destroy() {
+    for (const input of this.#inputs) {
+      input.removeDownstream(this.#listener);
+    }
+  }
+}

--- a/src/zql/ivm/graph/operators/difference-effect-operator.ts
+++ b/src/zql/ivm/graph/operators/difference-effect-operator.ts
@@ -38,6 +38,6 @@ export class DifferenceEffectOperator<T extends object> extends UnaryOperator<
         this.#f(val, mult);
       }
     }
-    this._output.commit(v);
+    super.commit(v);
   }
 }

--- a/src/zql/ivm/graph/operators/distinct-operator.test.ts
+++ b/src/zql/ivm/graph/operators/distinct-operator.test.ts
@@ -1,0 +1,61 @@
+import {expect, test} from 'vitest';
+import {Multiset} from '../../multiset.js';
+import {DifferenceStream} from '../difference-stream.js';
+
+test('distinct', () => {
+  type T = {
+    id: string;
+  };
+  const input = new DifferenceStream<T>();
+  const output = input.distinct();
+
+  let version = 1;
+
+  const items: Multiset<T>[] = [];
+  output.debug((v, d) => {
+    expect(v).toBe(version);
+    items.push(d);
+  });
+
+  input.newData(version, [
+    [{id: 'a'}, 1],
+    [{id: 'b'}, 2],
+    [{id: 'a'}, -1],
+    [{id: 'c'}, -3],
+  ]);
+  input.commit(version);
+
+  expect(items).toEqual([
+    [
+      [{id: 'b'}, 1],
+      [{id: 'c'}, -1],
+    ],
+  ]);
+
+  version++;
+  items.length = 0;
+  input.newData(version, [[{id: 'b'}, -2]]);
+  input.commit(version);
+  expect(items).toEqual([[[{id: 'b'}, -1]]]);
+
+  version++;
+  items.length = 0;
+  input.newData(version, [[{id: 'd'}, -1]]);
+  input.newData(version, [[{id: 'd'}, 1]]);
+  input.commit(version);
+  expect(items).toEqual([[[{id: 'd'}, -1]], [[{id: 'd'}, 1]]]);
+
+  version++;
+  items.length = 0;
+  input.newData(version, [[{id: 'e'}, -1]]);
+  input.newData(version, [[{id: 'e'}, 5]]);
+  input.commit(version);
+  expect(items).toEqual([[[{id: 'e'}, -1]], [[{id: 'e'}, 2]]]);
+
+  version++;
+  items.length = 0;
+  input.newData(version, [[{id: 'e'}, 5]]);
+  input.newData(version, [[{id: 'e'}, -6]]);
+  input.commit(version);
+  expect(items).toEqual([[[{id: 'e'}, 1]], [[{id: 'e'}, -2]]]);
+});

--- a/src/zql/ivm/graph/operators/distinct-operator.ts
+++ b/src/zql/ivm/graph/operators/distinct-operator.ts
@@ -1,0 +1,76 @@
+import {Entity} from '../../../../generate.js';
+import {Entry, Multiset} from '../../multiset.js';
+import {Version} from '../../types.js';
+import {DifferenceStream} from '../difference-stream.js';
+import {UnaryOperator} from './unary-operator.js';
+
+/**
+ * A dataflow operator that has a single input edge and a single output edge.
+ * It collapses multiple updates in the same transaction (version) to a single output.
+ * The multiplicity of the output entries is -1, 0, or 1 after the tx is done.
+ *
+ * The id property iu used to identify the entity.
+ */
+export class DistinctOperator<T extends Entity> extends UnaryOperator<T, T> {
+  // The entries for this version. The string is the ID of the entity.
+  readonly #entriesCache = new Map<Version, Map<string, Entry<T>>>();
+  // The emitted data for this version. The string is the ID of the entity. The
+  // number is the multiplicity outputted so far in this tx.
+  readonly #emitted = new Map<Version, Map<string, number>>();
+
+  constructor(input: DifferenceStream<T>, output: DifferenceStream<T>) {
+    super(input, output, (version, data) => this.#handleDiff(version, data));
+  }
+
+  #handleDiff(version: number, multiset: Multiset<T>): Multiset<T> {
+    // Clear data for old versions.
+    clearOldVersions(this.#entriesCache, version);
+    clearOldVersions(this.#emitted, version);
+
+    // Have we seen the data at this version before?
+    let entriesForThisVersion = this.#entriesCache.get(version);
+    if (!entriesForThisVersion) {
+      // First time we see the data.
+      entriesForThisVersion = new Map<string, Entry<T>>();
+      this.#entriesCache.set(version, entriesForThisVersion);
+    }
+
+    for (const entry of multiset) {
+      const {id} = entry[0];
+      const existingEntry = entriesForThisVersion.get(id);
+      entriesForThisVersion.set(
+        id,
+        existingEntry ? [entry[0], existingEntry[1] + entry[1]] : entry,
+      );
+    }
+
+    let emittedMap = this.#emitted.get(version);
+    if (!emittedMap) {
+      emittedMap = new Map();
+      this.#emitted.set(version, emittedMap);
+    }
+
+    const newMultiset: Entry<T>[] = [];
+    for (const [value, multiplicity] of entriesForThisVersion.values()) {
+      const {id} = value;
+      const existingMultiplicity = emittedMap.get(id) ?? 0;
+      const desiredMultiplicity = Math.sign(multiplicity);
+      if (existingMultiplicity !== desiredMultiplicity) {
+        newMultiset.push([value, desiredMultiplicity - existingMultiplicity]);
+        emittedMap.set(id, desiredMultiplicity);
+      }
+    }
+
+    return newMultiset;
+  }
+}
+
+function clearOldVersions(m: Map<Version, unknown>, version: Version) {
+  for (const v of m.keys()) {
+    if (v < version) {
+      m.delete(v);
+    } else {
+      return;
+    }
+  }
+}

--- a/src/zql/ivm/graph/operators/distinct-operator.ts
+++ b/src/zql/ivm/graph/operators/distinct-operator.ts
@@ -2,6 +2,7 @@ import {Entity} from '../../../../generate.js';
 import {Entry, Multiset} from '../../multiset.js';
 import {Version} from '../../types.js';
 import {DifferenceStream} from '../difference-stream.js';
+import {Request} from '../message.js';
 import {UnaryOperator} from './unary-operator.js';
 
 /**
@@ -13,64 +14,55 @@ import {UnaryOperator} from './unary-operator.js';
  */
 export class DistinctOperator<T extends Entity> extends UnaryOperator<T, T> {
   // The entries for this version. The string is the ID of the entity.
-  readonly #entriesCache = new Map<Version, Map<string, Entry<T>>>();
+  readonly #entriesCache = new Map<string, Entry<T>>();
   // The emitted data for this version. The string is the ID of the entity. The
   // number is the multiplicity outputted so far in this tx.
-  readonly #emitted = new Map<Version, Map<string, number>>();
+  readonly #emitted = new Map<string, number>();
+  readonly #seenUpstreamMessages = new Set<number>();
+  #lastSeenVersion: Version = -1;
 
   constructor(input: DifferenceStream<T>, output: DifferenceStream<T>) {
     super(input, output, (version, data) => this.#handleDiff(version, data));
   }
 
   #handleDiff(version: number, multiset: Multiset<T>): Multiset<T> {
-    // Clear data for old versions.
-    clearOldVersions(this.#entriesCache, version);
-    clearOldVersions(this.#emitted, version);
-
-    // Have we seen the data at this version before?
-    let entriesForThisVersion = this.#entriesCache.get(version);
-    if (!entriesForThisVersion) {
-      // First time we see the data.
-      entriesForThisVersion = new Map<string, Entry<T>>();
-      this.#entriesCache.set(version, entriesForThisVersion);
+    if (version > this.#lastSeenVersion) {
+      this.#entriesCache.clear();
+      this.#emitted.clear();
+      this.#lastSeenVersion = version;
     }
+
+    const entriesCache = this.#entriesCache;
+    const emitted = this.#emitted;
 
     for (const entry of multiset) {
       const {id} = entry[0];
-      const existingEntry = entriesForThisVersion.get(id);
-      entriesForThisVersion.set(
+      const existingEntry = entriesCache.get(id);
+      entriesCache.set(
         id,
         existingEntry ? [entry[0], existingEntry[1] + entry[1]] : entry,
       );
     }
 
-    let emittedMap = this.#emitted.get(version);
-    if (!emittedMap) {
-      emittedMap = new Map();
-      this.#emitted.set(version, emittedMap);
-    }
-
     const newMultiset: Entry<T>[] = [];
-    for (const [value, multiplicity] of entriesForThisVersion.values()) {
+    for (const [value, multiplicity] of entriesCache.values()) {
       const {id} = value;
-      const existingMultiplicity = emittedMap.get(id) ?? 0;
+      const existingMultiplicity = emitted.get(id) ?? 0;
       const desiredMultiplicity = Math.sign(multiplicity);
       if (existingMultiplicity !== desiredMultiplicity) {
         newMultiset.push([value, desiredMultiplicity - existingMultiplicity]);
-        emittedMap.set(id, desiredMultiplicity);
+        emitted.set(id, desiredMultiplicity);
       }
     }
 
     return newMultiset;
   }
-}
 
-function clearOldVersions(m: Map<Version, unknown>, version: Version) {
-  for (const v of m.keys()) {
-    if (v < version) {
-      m.delete(v);
-    } else {
-      return;
+  messageUpstream(message: Request): void {
+    // TODO(arv): Test this and validate that it is correct.
+    if (!this.#seenUpstreamMessages.has(message.id)) {
+      this.#seenUpstreamMessages.add(message.id);
+      super.messageUpstream(message);
     }
   }
 }

--- a/src/zql/ivm/graph/operators/operator.ts
+++ b/src/zql/ivm/graph/operators/operator.ts
@@ -1,11 +1,10 @@
 import {Version} from '../../types.js';
-import {DifferenceStream} from '../difference-stream.js';
 import {Request} from '../message.js';
 
 export interface Operator {
   /**
    * Notify along the graph that the transaction
-   * has been comitted
+   * has been committed
    */
   commit(version: Version): void;
   messageUpstream(message: Request): void;
@@ -17,30 +16,4 @@ export class NoOp implements Operator {
   commit(_v: Version): void {}
   messageUpstream(): void {}
   destroy(): void {}
-}
-
-/**
- * A dataflow operator (node) that has many incoming edges (stream) and one outgoing edge (stream).
- */
-export abstract class OperatorBase<O extends object> implements Operator {
-  // upstream inputs
-  protected readonly _inputs: DifferenceStream<object>[];
-  // downstream output
-  protected readonly _output: DifferenceStream<O>;
-
-  constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    inputs: DifferenceStream<any>[],
-    output: DifferenceStream<O>,
-  ) {
-    this._inputs = inputs;
-    this._output = output;
-  }
-
-  commit(v: Version) {
-    this._output.commit(v);
-  }
-
-  abstract messageUpstream(message: Request): void;
-  abstract destroy(): void;
 }

--- a/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/src/zql/ivm/graph/operators/unary-operator.ts
@@ -32,8 +32,8 @@ export class UnaryOperator<I extends object, O extends object>
     this.#output = output;
   }
 
-  commit(v: number): void {
-    this.#output.commit(v);
+  commit(version: Version): void {
+    this.#output.commit(version);
   }
 
   messageUpstream(message: Request): void {

--- a/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/src/zql/ivm/graph/operators/unary-operator.ts
@@ -1,25 +1,24 @@
-import {Version} from '../../types.js';
-import {OperatorBase} from './operator.js';
-import {DifferenceStream, Listener} from '../difference-stream.js';
 import {Multiset} from '../../multiset.js';
+import {Version} from '../../types.js';
+import {DifferenceStream, Listener} from '../difference-stream.js';
 import {Request} from '../message.js';
+import {Operator} from './operator.js';
 
 /**
  * Operator that only takes a single argument
  */
-export class UnaryOperator<
-  I extends object,
-  O extends object,
-> extends OperatorBase<O> {
+export class UnaryOperator<I extends object, O extends object>
+  implements Operator
+{
   readonly #listener: Listener<I>;
   readonly #input: DifferenceStream<I>;
+  readonly #output: DifferenceStream<O>;
 
   constructor(
     input: DifferenceStream<I>,
     output: DifferenceStream<O>,
     fn: (version: Version, data: Multiset<I>) => Multiset<O>,
   ) {
-    super([input], output);
     this.#listener = {
       newDifference: (version, data) => {
         output.newData(version, fn(version, data));
@@ -30,6 +29,11 @@ export class UnaryOperator<
     };
     input.addDownstream(this.#listener);
     this.#input = input;
+    this.#output = output;
+  }
+
+  commit(v: number): void {
+    this.#output.commit(v);
   }
 
   messageUpstream(message: Request): void {

--- a/src/zql/ivm/view/tree-view.ts
+++ b/src/zql/ivm/view/tree-view.ts
@@ -1,12 +1,11 @@
 import {Treap} from '@vlcn.io/ds-and-algos/Treap';
 import {Comparator, ITree} from '@vlcn.io/ds-and-algos/types';
+import {Ordering} from '../../ast/ast.js';
 import {DifferenceStream} from '../graph/difference-stream.js';
+import {createPullMessage} from '../graph/message.js';
 import {Materialite} from '../materialite.js';
 import {Multiset} from '../multiset.js';
-import {Version} from '../types.js';
 import {AbstractView} from './abstract-view.js';
-import {Ordering} from '../../ast/ast.js';
-import {createPullMessage} from '../graph/message.js';
 
 /**
  * A sink that maintains the list of values in-order.
@@ -59,21 +58,21 @@ export class MutableTreeView<T extends object> extends AbstractView<T, T[]> {
     return this.#jsSlice;
   }
 
-  protected _newData(version: Version, data: Multiset<T>) {
+  protected _newDifference(data: Multiset<T>): boolean {
     let changed = false;
 
     let newData = this.#data;
     [changed, newData] = this.#sink(data, newData, changed);
     this.#data = newData;
 
-    if (!changed) {
-      this._notifiedListenersVersion = version;
-    } else {
+    if (changed) {
       // idk.. would be more efficient for users to just use the
       // treap directly. We have a PersistentTreap variant for React users
       // or places where immutability is important.
       this.#jsSlice = this.#data.toArray();
     }
+
+    return changed;
   }
 
   #sink(c: Multiset<T>, data: ITree<T>, changed: boolean): [boolean, ITree<T>] {


### PR DESCRIPTION
This supersedes #52

OR is implemented by branching the graph when an OR expression is encountered. Each OR branch is executed "in parallel" and then merged together. The merging is done using `concat` and then `distinct`. 

For example if we have:

```sql
SELECT * FROM table WHERE (a=1 OR b=1) AND (a=2 OR b=2)
```

We get something like:

```mermaid
  graph TD;
      Root-->id1;
      Root-->id2;
      id1(a=1) --> c1;
      id2(b=1) --> c1;
      c1(Concat) --> d1;
      d1(Distinct) --> id3;
      d1 --> id4;
      id3(a=2) --> c2;
      id4(b=2) --> c2;
      c2(Concat) --> d2;
      d2(Distinct)


```