### PR TITLE
fix(zql): Fix LIKE and ILIKE

### DIFF
--- a/src/zql/ast-to-ivm/pipeline-builder.test.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.test.ts
@@ -500,6 +500,18 @@ describe('getOperator', () => {
     })),
     {op: 'LIKE', left: 'a%b', right: 'a\\%b', expected: true},
     {op: 'LIKE', left: 'a_b', right: 'a\\_b', expected: true},
+
+    {op: 'LIKE', left: 'a\\bc', right: 'a\\\\bc', expected: true},
+    {op: 'LIKE', left: 'a\\Bc', right: 'a\\\\Bc', expected: true},
+    {op: 'LIKE', left: 'ab', right: 'a\\b', expected: true},
+    {op: 'LIKE', left: 'a"b', right: 'a"b', expected: true},
+    {op: 'LIKE', left: "a'b", right: "a'b", expected: true},
+
+    {op: 'LIKE', left: 'a{', right: 'a{', expected: true},
+    {op: 'LIKE', left: 'a{', right: 'a\\{', expected: true},
+    {op: 'LIKE', left: 'a\n', right: 'a\n', expected: true},
+    {op: 'LIKE', left: 'an', right: 'a\\n', expected: true},
+    {op: 'LIKE', left: 'a ', right: 'a\\s', expected: false},
   ] as const;
 
   for (const c of cases) {
@@ -535,6 +547,14 @@ describe('getOperator', () => {
       });
     }
   }
+
+  expect(() =>
+    getOperator({
+      op: 'LIKE',
+      field: 'field',
+      value: {type: 'literal', value: '\\'},
+    } as SimpleCondition),
+  ).toThrow('LIKE pattern must not end with escape character');
 });
 
 // order-by and limit are properties of the materialize view

--- a/src/zql/integration.test.ts
+++ b/src/zql/integration.test.ts
@@ -282,11 +282,11 @@ test('each where operator', async () => {
   // expect(await stmt.exec()).toEqual([{id: 'a'}, {id: 'b'}]);
   // stmt.destroy();
 
-  stmt = q.select('id').where('assignee', 'LIKE', 'al').prepare();
+  stmt = q.select('id').where('assignee', 'LIKE', 'al%').prepare();
   expect(await stmt.exec()).toEqual([{id: 'c'}]);
   stmt.destroy();
 
-  stmt = q.select('id').where('assignee', 'ILIKE', 'AL').prepare();
+  stmt = q.select('id').where('assignee', 'ILIKE', 'AL%').prepare();
   expect(await stmt.exec()).toEqual([{id: 'c'}]);
   stmt.destroy();
 


### PR DESCRIPTION
https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

Our implementation of LIKE and ILIKE was incorrect. Now it should match the PSQL spec.