### PR TITLE
types: allow EntityQuery to select from many tables

### DIFF
--- a/src/zql/ast-to-ivm/pipeline-builder.test.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.test.ts
@@ -27,7 +27,7 @@ type E1 = z.infer<typeof e1>;
 const context = makeTestContext();
 const comparator = (l: E1, r: E1) => compareUTF8(l.id, r.id);
 test('A simple select', () => {
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   let s = m.newSetSource<E1>(comparator);
   let pipeline = buildPipeline(
@@ -69,7 +69,7 @@ test('A simple select', () => {
 });
 
 test('Count', () => {
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   const s = m.newSetSource<E1>(comparator);
   const pipeline = buildPipeline(
@@ -99,7 +99,7 @@ test('Count', () => {
 });
 
 test('Where', () => {
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   const s = m.newSetSource<E1>(comparator);
   const pipeline = buildPipeline(
@@ -133,7 +133,7 @@ describe('OR', () => {
 
   type Case = {
     name?: string | undefined;
-    where: WhereCondition<E>;
+    where: WhereCondition<{e1: E}>;
     values?: (E | DeleteE)[] | undefined;
     expected: (E | [v: E, multiplicity: number])[];
   };
@@ -377,7 +377,11 @@ describe('OR', () => {
 
       const ast: AST = {
         table: 'items',
-        select: ['id', 'a', 'b'],
+        select: [
+          ['id', 'id'],
+          ['a', 'a'],
+          ['b', 'b'],
+        ],
         where: c.where as Condition,
         orderBy: [['id'], 'asc'],
       };

--- a/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -62,7 +62,7 @@ export function buildPipeline(
 
 export function applySelect(
   stream: DifferenceStream<Entity>,
-  select: string[],
+  select: [string, string][],
   orderBy: Ordering | undefined,
 ) {
   return stream.map(x => {
@@ -71,8 +71,8 @@ export function applySelect(
       ret = {...x};
     } else {
       ret = {};
-      for (const field of select) {
-        ret[field] = (x as Record<string, unknown>)[field];
+      for (const selector of select) {
+        ret[selector[1]] = (x as Record<string, unknown>)[selector[0]];
       }
     }
 
@@ -168,7 +168,7 @@ function applyGroupBy<T extends Entity>(
   stream: DifferenceStream<T>,
   columns: string[],
   aggregations: Aggregation[],
-  select: string[],
+  select: [string, string][],
   orderBy: Ordering | undefined,
 ) {
   const keyFunction = makeKeyFunction(columns);
@@ -178,8 +178,8 @@ function applyGroupBy<T extends Entity>(
     values => {
       const first = values[Symbol.iterator]().next().value;
       const ret: Record<string, unknown> = {};
-      for (const column of select) {
-        ret[column] = first[column];
+      for (const selector of select) {
+        ret[selector[1]] = first[selector[0]];
       }
       addOrdering(ret, first, orderBy);
 

--- a/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -62,7 +62,7 @@ export function buildPipeline(
 
 export function applySelect(
   stream: DifferenceStream<Entity>,
-  select: [string, string][],
+  select: [column: string, alias: string][],
   orderBy: Ordering | undefined,
 ) {
   return stream.map(x => {

--- a/src/zql/ast/ast.ts
+++ b/src/zql/ast/ast.ts
@@ -27,7 +27,7 @@ export type Aggregation = {
 export type AST = {
   readonly table?: string | undefined;
   readonly alias?: number | undefined;
-  readonly select?: string[] | undefined;
+  readonly select?: [string, string][] | undefined;
   readonly aggregate?: Aggregation[];
   // readonly subQueries?: {
   //   readonly alias: string;

--- a/src/zql/context/replicache-context.test.ts
+++ b/src/zql/context/replicache-context.test.ts
@@ -140,7 +140,7 @@ test('ZQL query with Replicache', async () => {
   const r = newRep();
   const context = makeReplicacheContext(r);
 
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const view = q.select('id').where('str', '>', 'm').prepare().view();
 

--- a/src/zql/integration.test.ts
+++ b/src/zql/integration.test.ts
@@ -84,7 +84,7 @@ function sampleTenUniqueIssues() {
 function setup() {
   const r = newRep();
   const c = makeReplicacheContext(r);
-  const q = new EntityQuery<Issue>(c, 'issue');
+  const q = new EntityQuery<{issue: Issue}>(c, 'issue');
   return {r, c, q};
 }
 

--- a/src/zql/ivm/view/tree-view.test.ts
+++ b/src/zql/ivm/view/tree-view.test.ts
@@ -17,7 +17,7 @@ test('asc and descComparator on Entities', () => {
 
   const updatedStream = applySelect(
     s.stream,
-    ['id'],
+    [['id', 'id']],
     [['n', 'id'], 'asc'],
   ) as unknown as DifferenceStream<Selected>;
 
@@ -29,7 +29,7 @@ test('asc and descComparator on Entities', () => {
     m,
     applySelect(
       s.stream as unknown as DifferenceStream<Entity>,
-      ['id'],
+      [['id', 'id']],
       [['n', 'id'], 'desc'],
     ) as unknown as DifferenceStream<Selected>,
     descComparator,

--- a/src/zql/query/condition-to-string.ts
+++ b/src/zql/query/condition-to-string.ts
@@ -1,8 +1,7 @@
-import {EntitySchema} from '../schema/entity-schema.js';
-import {WhereCondition} from './entity-query.js';
+import {FromSet, WhereCondition} from './entity-query.js';
 
-export function conditionToString<S extends EntitySchema>(
-  c: WhereCondition<S>,
+export function conditionToString<From extends FromSet>(
+  c: WhereCondition<From>,
   paren = false,
 ): string {
   if (c.op === 'AND' || c.op === 'OR') {

--- a/src/zql/query/entity-query.test.ts
+++ b/src/zql/query/entity-query.test.ts
@@ -6,9 +6,10 @@ import * as agg from './agg.js';
 import {conditionToString} from './condition-to-string.js';
 import {
   EntityQuery,
-  FieldValue,
+  FieldAsOperatorInput,
   WhereCondition,
   and,
+  as,
   astForTesting,
   expression,
   not,
@@ -30,7 +31,7 @@ test('query types', () => {
     [sym]: boolean;
   };
 
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   // @ts-expect-error - selecting fields that do not exist in the schema is a type error
   q.select('does-not-exist');
@@ -71,6 +72,16 @@ test('query types', () => {
 
   // @ts-expect-error - 'x' is not a field that we can aggregate on
   q.select(agg.array('x')).groupBy('id');
+
+  expectTypeOf(
+    q
+      .select('optStr', as('e1.optStr', 'alias'))
+      .groupBy('optStr')
+      .prepare()
+      .exec(),
+  ).toMatchTypeOf<
+    Promise<readonly {optStr: string | undefined; alias: string | undefined}[]>
+  >();
 
   expectTypeOf(
     q.select('id', agg.array('str')).groupBy('optStr').prepare().exec(),
@@ -123,76 +134,114 @@ test('query types', () => {
 
 test('FieldValue type', () => {
   type E = {
-    id: string;
-    n: number;
-    s: string;
-    b: boolean;
-    optN?: number | undefined;
-    optS?: string | undefined;
-    optB?: boolean | undefined;
+    e: {
+      id: string;
+      n: number;
+      s: string;
+      b: boolean;
+      optN?: number | undefined;
+      optS?: string | undefined;
+      optB?: boolean | undefined;
+    };
   };
-  expectTypeOf<FieldValue<E, 'id', '='>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'n', '='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 's', '!='>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'b', '='>>().toEqualTypeOf<boolean>();
-  expectTypeOf<FieldValue<E, 'optN', '='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'optS', '!='>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optB', '='>>().toEqualTypeOf<boolean>();
+  expectTypeOf<FieldAsOperatorInput<E, 'id', '='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', '='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', '!='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', '='>>().toEqualTypeOf<boolean>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', '='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', '!='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', '='>>().toEqualTypeOf<boolean>();
 
   // booleans not allowed with order operators
-  expectTypeOf<FieldValue<E, 'b', '<'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'b', '<='>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'b', '>'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'b', '>='>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'n', '<'>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'n', '<='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'n', '>'>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'n', '>='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 's', '<'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 's', '<='>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 's', '>'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 's', '>='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', '<'>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', '<='>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', '>'>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', '>='>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', '<'>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', '<='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', '>'>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', '>='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', '<'>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', '<='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', '>'>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', '>='>>().toEqualTypeOf<string>();
 
-  expectTypeOf<FieldValue<E, 'optB', '<'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optB', '<='>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optB', '>'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optB', '>='>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optN', '<'>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'optN', '<='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'optN', '>'>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'optN', '>='>>().toEqualTypeOf<number>();
-  expectTypeOf<FieldValue<E, 'optS', '<'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optS', '<='>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optS', '>'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optS', '>='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', '<'>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', '<='>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', '>'>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', '>='>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', '<'>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', '<='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', '>'>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', '>='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', '<'>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', '<='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', '>'>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', '>='>>().toEqualTypeOf<string>();
 
-  expectTypeOf<FieldValue<E, 'n', 'IN'>>().toEqualTypeOf<number[]>();
-  expectTypeOf<FieldValue<E, 'n', 'NOT IN'>>().toEqualTypeOf<number[]>();
-  expectTypeOf<FieldValue<E, 's', 'IN'>>().toEqualTypeOf<string[]>();
-  expectTypeOf<FieldValue<E, 's', 'NOT IN'>>().toEqualTypeOf<string[]>();
-  expectTypeOf<FieldValue<E, 'b', 'IN'>>().toEqualTypeOf<boolean[]>();
-  expectTypeOf<FieldValue<E, 'b', 'NOT IN'>>().toEqualTypeOf<boolean[]>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', 'IN'>>().toEqualTypeOf<number[]>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', 'NOT IN'>>().toEqualTypeOf<
+    number[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 's', 'IN'>>().toEqualTypeOf<string[]>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', 'NOT IN'>>().toEqualTypeOf<
+    string[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', 'IN'>>().toEqualTypeOf<boolean[]>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', 'NOT IN'>>().toEqualTypeOf<
+    boolean[]
+  >();
 
-  expectTypeOf<FieldValue<E, 'optN', 'IN'>>().toEqualTypeOf<number[]>();
-  expectTypeOf<FieldValue<E, 'optN', 'NOT IN'>>().toEqualTypeOf<number[]>();
-  expectTypeOf<FieldValue<E, 'optS', 'IN'>>().toEqualTypeOf<string[]>();
-  expectTypeOf<FieldValue<E, 'optS', 'NOT IN'>>().toEqualTypeOf<string[]>();
-  expectTypeOf<FieldValue<E, 'optB', 'IN'>>().toEqualTypeOf<boolean[]>();
-  expectTypeOf<FieldValue<E, 'optB', 'NOT IN'>>().toEqualTypeOf<boolean[]>();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', 'IN'>>().toEqualTypeOf<
+    number[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'optN', 'NOT IN'>>().toEqualTypeOf<
+    number[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', 'IN'>>().toEqualTypeOf<
+    string[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'optS', 'NOT IN'>>().toEqualTypeOf<
+    string[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', 'IN'>>().toEqualTypeOf<
+    boolean[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'optB', 'NOT IN'>>().toEqualTypeOf<
+    boolean[]
+  >();
 
-  expectTypeOf<FieldValue<E, 'n', 'LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'n', 'NOT LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 's', 'LIKE'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 's', 'NOT LIKE'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'b', 'LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'b', 'NOT LIKE'>>().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 'n', 'LIKE'>>().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'n', 'NOT LIKE'>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<FieldAsOperatorInput<E, 's', 'LIKE'>>().toEqualTypeOf<string>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 's', 'NOT LIKE'>
+  >().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'b', 'LIKE'>>().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'b', 'NOT LIKE'>
+  >().toEqualTypeOf<never>();
 
-  expectTypeOf<FieldValue<E, 'optN', 'LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optN', 'NOT LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optS', 'LIKE'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optS', 'NOT LIKE'>>().toEqualTypeOf<string>();
-  expectTypeOf<FieldValue<E, 'optB', 'LIKE'>>().toEqualTypeOf<never>();
-  expectTypeOf<FieldValue<E, 'optB', 'NOT LIKE'>>().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optN', 'LIKE'>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optN', 'NOT LIKE'>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optS', 'LIKE'>
+  >().toEqualTypeOf<string>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optS', 'NOT LIKE'>
+  >().toEqualTypeOf<string>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optB', 'LIKE'>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'optB', 'NOT LIKE'>
+  >().toEqualTypeOf<never>();
 
   const q = new EntityQuery<E>(context, 'e');
   q.where('n', '<', 1);
@@ -249,24 +298,24 @@ const dummyObject: E1 = {
 };
 describe('ast', () => {
   test('select', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // each individual field is selectable on its own
     Object.keys(dummyObject).forEach(k => {
       const newq = q.select(k as keyof E1);
-      expect(ast(newq).select).toEqual([k]);
+      expect(ast(newq).select).toEqual([[k, k]]);
     });
 
     // all fields are selectable together
     let newq = q.select(...(Object.keys(dummyObject) as (keyof E1)[]));
-    expect(ast(newq).select).toEqual(Object.keys(dummyObject));
+    expect(ast(newq).select).toEqual(Object.keys(dummyObject).map(k => [k, k]));
 
     // we can call select many times to build up the selection set
     newq = q;
     Object.keys(dummyObject).forEach(k => {
       newq = newq.select(k as keyof E1);
     });
-    expect(ast(newq).select).toEqual(Object.keys(dummyObject));
+    expect(ast(newq).select).toEqual(Object.keys(dummyObject).map(k => [k, k]));
 
     // we remove duplicates
     newq = q;
@@ -276,11 +325,11 @@ describe('ast', () => {
     Object.keys(dummyObject).forEach(k => {
       newq = newq.select(k as keyof E1);
     });
-    expect(ast(newq).select).toEqual(Object.keys(dummyObject));
+    expect(ast(newq).select).toEqual(Object.keys(dummyObject).map(k => [k, k]));
   });
 
   test('where', () => {
-    let q = new EntityQuery<E1>(context, 'e1');
+    let q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // where is applied
     q = q.where('id', '=', 'a');
@@ -365,7 +414,7 @@ describe('ast', () => {
   });
 
   test('limit', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
     expect(ast(q.limit(10))).toEqual({
       orderBy: [['id'], 'asc'],
       table: 'e1',
@@ -374,7 +423,7 @@ describe('ast', () => {
   });
 
   test('asc/desc', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // order methods update the ast
     expect(ast(q.asc('id'))).toEqual({
@@ -392,7 +441,7 @@ describe('ast', () => {
   });
 
   test('independent of method call order', () => {
-    const base = new EntityQuery<E1>(context, 'e1');
+    const base = new EntityQuery<{e1: E1}>(context, 'e1');
 
     const calls = {
       select(q: typeof base) {
@@ -431,7 +480,7 @@ describe('ast', () => {
   });
 
   test('or', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(
       ast(q.where(or(expression('a', '=', 123), expression('c', '=', 'abc')))),
@@ -476,7 +525,7 @@ describe('ast', () => {
   });
 
   test('flatten ands', () => {
-    type S = {id: string; a: number; b: string; c: boolean; d: string};
+    type S = {s: {id: string; a: number; b: string; c: boolean; d: string}};
 
     expect(
       and<S>(
@@ -539,7 +588,7 @@ describe('ast', () => {
   });
 
   test('flatten ors', () => {
-    type S = {id: string; a: number; b: string; c: boolean; d: string};
+    type S = {s: {id: string; a: number; b: string; c: boolean; d: string}};
 
     expect(
       or<S>(
@@ -558,7 +607,7 @@ describe('ast', () => {
   });
 
   test('consecutive wheres/ands should be merged', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(
       ast(
@@ -693,7 +742,7 @@ describe('ast', () => {
   });
 
   test('consecutive ors', () => {
-    const q = new EntityQuery<E1>(context, 'e1');
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(
       ast(q.where(or(expression('a', '=', 123), expression('a', '=', 456))))
@@ -798,7 +847,7 @@ describe('NOT', () => {
 
     for (const c of cases) {
       test(`${c.in} -> ${c.out}`, () => {
-        const q = new EntityQuery<E1>(context, 'e1');
+        const q = new EntityQuery<{e1: E1}>(context, 'e1');
         expect(ast(q.where(not(expression('a', c.in, 1)))).where).toEqual({
           op: c.out,
           field: 'a',
@@ -811,9 +860,11 @@ describe('NOT', () => {
 
 describe("De Morgan's Law", () => {
   type S = {
-    id: string;
-    n: number;
-    s: string;
+    s: {
+      id: string;
+      n: number;
+      s: string;
+    };
   };
 
   const cases: {

--- a/src/zql/query/entity-query.test.ts
+++ b/src/zql/query/entity-query.test.ts
@@ -7,6 +7,7 @@ import {conditionToString} from './condition-to-string.js';
 import {
   EntityQuery,
   FieldAsOperatorInput,
+  ValueAsOperatorInput,
   WhereCondition,
   and,
   as,
@@ -145,12 +146,24 @@ test('FieldValue type', () => {
     };
   };
   expectTypeOf<FieldAsOperatorInput<E, 'id', '='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'e.id', '='>>().toEqualTypeOf<string>();
   expectTypeOf<FieldAsOperatorInput<E, 'n', '='>>().toEqualTypeOf<number>();
+  expectTypeOf<FieldAsOperatorInput<E, 'e.n', '='>>().toEqualTypeOf<number>();
   expectTypeOf<FieldAsOperatorInput<E, 's', '!='>>().toEqualTypeOf<string>();
+  expectTypeOf<FieldAsOperatorInput<E, 'e.s', '!='>>().toEqualTypeOf<string>();
   expectTypeOf<FieldAsOperatorInput<E, 'b', '='>>().toEqualTypeOf<boolean>();
   expectTypeOf<FieldAsOperatorInput<E, 'optN', '='>>().toEqualTypeOf<number>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'e.optN', '='>
+  >().toEqualTypeOf<number>();
   expectTypeOf<FieldAsOperatorInput<E, 'optS', '!='>>().toEqualTypeOf<string>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'e.optS', '!='>
+  >().toEqualTypeOf<string>();
   expectTypeOf<FieldAsOperatorInput<E, 'optB', '='>>().toEqualTypeOf<boolean>();
+  expectTypeOf<
+    FieldAsOperatorInput<E, 'e.optB', '='>
+  >().toEqualTypeOf<boolean>();
 
   // booleans not allowed with order operators
   expectTypeOf<FieldAsOperatorInput<E, 'b', '<'>>().toEqualTypeOf<never>();
@@ -187,7 +200,12 @@ test('FieldValue type', () => {
   expectTypeOf<FieldAsOperatorInput<E, 's', 'NOT IN'>>().toEqualTypeOf<
     string[]
   >();
-  expectTypeOf<FieldAsOperatorInput<E, 'b', 'IN'>>().toEqualTypeOf<boolean[]>();
+  expectTypeOf<ValueAsOperatorInput<boolean, 'IN'>>().toEqualTypeOf<
+    boolean[]
+  >();
+  expectTypeOf<FieldAsOperatorInput<E, 'e.b', 'IN'>>().toEqualTypeOf<
+    boolean[]
+  >();
   expectTypeOf<FieldAsOperatorInput<E, 'b', 'NOT IN'>>().toEqualTypeOf<
     boolean[]
   >();

--- a/src/zql/query/entity-query.ts
+++ b/src/zql/query/entity-query.ts
@@ -98,7 +98,7 @@ type ExtractFieldPiece<From extends FromSet, Selection extends Selector<From>> =
         ? From[Table]
         : never
       : // 'table.column'
-        Selection extends `${infer _Table}.${infer Column}`
+        Selection extends `${string}.${infer Column}`
         ? {
             [K in Column]: ExtractFieldValue<From, Selection>;
           }
@@ -428,19 +428,3 @@ function negateOperator(op: SimpleOperator): SimpleOperator {
       return 'ILIKE';
   }
 }
-
-// const q: EntityQuery<{
-//   user: {
-//     id: string;
-//     name: string;
-//     foo: boolean;
-//   };
-//   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-// }> = {} as any;
-
-// import * as agg from './agg.js';
-
-// const x = q.select('user.*', agg.min('foo')).prepare().exec();
-
-// const f = q.select('name', 'user.id').where('name', '!=', '').prepare().exec();
-// const g = q.select(agg.avg('name')).prepare().exec();

--- a/src/zql/query/statement.test.ts
+++ b/src/zql/query/statement.test.ts
@@ -13,7 +13,7 @@ const e1 = z.object({
 type E1 = z.infer<typeof e1>;
 test('basic materialization', () => {
   const context = makeTestContext();
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const stmt = q.select('id', 'n').where('n', '>', 100).prepare();
 
@@ -43,7 +43,7 @@ test('basic materialization', () => {
 test('sorted materialization', () => {
   const context = makeTestContext();
   type E1 = z.infer<typeof e1>;
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const ascView = q.select('id').asc('n').prepare().view();
   const descView = q.select('id').desc('n').prepare().view();
 
@@ -67,7 +67,7 @@ test('sorted materialization', () => {
 test('sorting is stable via suffixing the primary key to the order', () => {
   const context = makeTestContext();
   type E1 = z.infer<typeof e1>;
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const ascView = q.select('id').asc('n').prepare().view();
   const descView = q.select('id').desc('n').prepare().view();
@@ -115,7 +115,7 @@ test('ascComparator', () => {
 
 test('destroying the statement stops updating the view', async () => {
   const context = makeTestContext();
-  const q = new EntityQuery<E1>(context, 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const stmt = q.select('id', 'n').prepare();
 


### PR DESCRIPTION
Doing `join` will bring in more tables that can be selected against. Thus, `EntityQuery.select` needs to be able pull from more than a single schema.

To do that, `EntityQuery` now takes a `FromSet` rather than `EntitySchema`.

```ts
type FromSet = {
  [table: string]: EntitySchema
};

const q = new EntityQuery<{issue: Issue}>();
const q2 = new EntityQuery<{user: User}>();

q.join(q2, 'owner', 'issue.ownerId', 'owner.id').select(...);
```

`join` requires us to support aliasing ambiguous columns so this adds that as well.

![image](https://github.com/rocicorp/rails/assets/1009003/445cd9e7-03a9-4a45-b3c1-3f9ba6d29e94)


```ts
// aliasing: x as y
foo.select(['x', 'y'])
// qualifying
foo.select('foo.bar', 'baz.x').join(Baz, 'baz_id', 'id');
// unqualified works too if the column is not ambiguous
foo.select('bar');
// added support for *
foo.select('issue.*')
```

<img width="357" alt="Screenshot 2024-04-04 at 11 26 54 PM" src="https://github.com/rocicorp/rails/assets/1009003/0cfc1cd0-9b62-48b6-9423-ae63ac753d02">
