### PR TITLE
Allow an Input type param to be passed to Generate

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -871,7 +871,7 @@ test('input/output types', async () => {
   } as unknown as NodeJS.Process;
 
   const generated = generate<z.infer<typeof inputOutput>, z.input<typeof inputOutput>>('inputOutput', inputOutput.parse);
-  const {get, list, listIDs} = generated;
+  const {get} = generated;
 
   const r = new Replicache({
     name: nanoid(),

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -857,3 +857,34 @@ test('undefined parse', async () => {
   const l2 = await r.query(tx => listIDs(tx));
   expect(l2).deep.eq(['invalid', 'valid']);
 });
+
+
+const inputOutput = z.object({
+  id: z.string(),
+  defaulted: z.string().default("The default")
+})
+test('input/output types', async () => {
+  globalThis.process = {
+    env: {
+      NODE_ENV: '',
+    },
+  } as unknown as NodeJS.Process;
+
+  const generated = generate<z.infer<typeof inputOutput>, z.input<typeof inputOutput>>('inputOutput', inputOutput.parse);
+  const {get, list, listIDs} = generated;
+
+  const r = new Replicache({
+    name: nanoid(),
+    mutators: generated,
+    licenseKey: TEST_LICENSE_KEY,
+  });
+  let v = await r.query(tx => get(tx, 'valid'));
+  expect(v).eq(undefined);
+
+  await r.mutate.set({id: 'defaulted'});
+  await r.mutate.set({id: 'set-default', defaulted: 'baz'});
+  v = await r.query(tx => get(tx, 'defaulted'));
+  expect(v).deep.eq({id: 'defaulted', defaulted: 'The default'});
+  v = await r.query(tx => get(tx, 'set-default'));
+  expect(v).deep.eq({id: 'set-default', defaulted: 'baz'});
+})


### PR DESCRIPTION
Zod has a concept of `z.input<>` which makes `default` things optional. It is often equal to `z.infer<>` but nice to use when it is not. 

This adds a second type param `Input` which is equal to `Output` (previously `T`) by default.

The fact that parse is typed with `Output` reads a little weird but I think correct because it uses that type as the return type, and `z.input<typeof x>` will return `z.infer<typeof x>`.